### PR TITLE
Draft: Enable MD001

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,5 @@
 {
     "default": true,
-    "MD001": false,
     "MD004": false,
     "MD013": false,
     "MD022": false,


### PR DESCRIPTION
This is to see how big the violations of this rule.

The [documentation of the rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md001---heading-levels-should-only-increment-by-one-level-at-a-time) mentions that violations affect accessibility scenarios. Given that this repo is much smaller than dotnet/docs, the violations *could* be manageable to fix. If they are too many, I'll close.