### PR TITLE
Clarify Panel.Background text.

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md
+++ b/dotnet-desktop-guide/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md
@@ -302,7 +302,7 @@ In this section, you'll update the home page UI with an image and a page title.
 
     [!code-xaml[ExpenseIt#12](~/samples/snippets/csharp/VS_Snippets_Wpf/ExpenseIt/CSharp/ExpenseIt5/ExpenseItHome.xaml#12)]
 
-5. Set the <xref:System.Windows.Controls.Panel.Background%2A?displayProperty=nameWithType> property to the *watermark.png* image file, by adding the following XAML anywhere between the `<Grid>` and `</Grid>` tags:
+5. Set the [Background](xref:System.Windows.Controls.Panel.Background%2A) property to the *watermark.png* image file, by adding the following XAML anywhere between the `<Grid>` and `</Grid>` tags:
 
     [!code-xaml[ExpenseIt#14](~/samples/snippets/csharp/VS_Snippets_Wpf/ExpenseIt/CSharp/ExpenseIt5/ExpenseItHome.xaml#14)]
 


### PR DESCRIPTION
## Summary

Force link text to simply say background.

Fixes #137
