### PR TITLE
Fix "Smooth quadratic Bezier curve Command" syntax

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
@@ -159,11 +159,10 @@ An uppercase `V` indicates that `y` is an absolute value; a lowercase `v` indica
   
 |Syntax|  
 |------------|  
-|`T` `controlPoint` `endPoint`<br /><br /> - or -<br /><br /> `t` `controlPoint` `endPoint`|  
+|`T` `endPoint`<br /><br /> - or -<br /><br /> `t` `endPoint`|  
   
 |Term|Description|  
 |----------|-----------------|  
-|`controlPoint`|<xref:System.Windows.Point?displayProperty=nameWithType><br /><br /> The control point of the curve, which determines the starting and tangent of the curve.|  
 |`endPoint`|<xref:System.Windows.Point?displayProperty=nameWithType><br /><br /> The point to which the curve is drawn.|  
   
 ### Elliptical Arc Command  


### PR DESCRIPTION
## Summary

According to the source code of WPF, we can know that the `T` command only receives one parameter which is the `endPoint`. The `controlPoint` argument is automatically calculated by the reflection of the last control point. So the previous version of this doc has error in `T` and I'm fixing it in this pull request.

## Reference

This is the code from WPF repo. If the command is `T`, it doesn't read any control point.

```csharp
case 'q': case 'Q': // quadratic Bezier
case 't': case 'T': // smooth quadratic Bezier
    EnsureFigure();
    
    do
    {
        if ((cmd == 't') || (cmd == 'T'))
        {
            if (last_cmd == 'Q')
            {
                _secondLastPoint = Reflect();
            }
            else
            {
                _secondLastPoint = _lastPoint;
            }

            _lastPoint = ReadPoint(cmd, ! AllowComma);
        }
        else
        {
            _secondLastPoint = ReadPoint(cmd, ! AllowComma);
            _lastPoint = ReadPoint(cmd, AllowComma);
        }

        context.QuadraticBezierTo(_secondLastPoint, _lastPoint, IsStroked, ! IsSmoothJoin);
        
        last_cmd = 'Q';
    }
    while (IsNumber(AllowComma));
    
    break;
```

You can view the code here:

- https://source.dot.net/#PresentationCore/System/Windows/Media/parserscommon.cs,646