### PR TITLE
Fix migration article for winforms

### DIFF
--- a/dotnet-desktop-guide/net/winforms/migration/index.md
+++ b/dotnet-desktop-guide/net/winforms/migration/index.md
@@ -173,7 +173,7 @@ Any _*.resx_ and _*.settings_ files in the _Properties_ folder need to be migrat
 
   ```xml
   <ItemGroup>
-    <None Include="Properties\Settings.settings">
+    <None Update="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
@@ -184,8 +184,6 @@ Any _*.resx_ and _*.settings_ files in the _Properties_ folder need to be migrat
     </Compile>
   </ItemGroup>
   ```
-
-  Notice that the _Properties\Settings.settings_ entry remained `Include`. The project doesn't automatically include _settings_ files.
 
   > [!IMPORTANT]
   > **Visual Basic** projects typically use the folder _My Project_ while C# projects typically use the folder _Properties_ for the default project settings file.


### PR DESCRIPTION
## Summary

As @Romanx pointed out, these .settings files **are** included in the project. However, the declarations are still required in the project file for the IDE to associate the files together in the Project Explorer.

I updated the example to swap `Include` to `Update` and removed the note.

Fixes #1124