### PR TITLE
add config for required actions

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -1,27 +1,12 @@
 # This is a basic workflow to help you get started with Actions
-name: Snippets 5000
+name: 'Snippets 5000'
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 on:
-  pull_request:
+  pull_request_target:
     paths:
-      - "**.cs"
-      - "**.vb"
-      - "**.fs"
-      - "**.cpp"
-      - "**.h"
-      - "**.xaml"
-      - "**.razor"
-      - "**.cshtml"
-      - "**.vbhtml"
-      - "**.csproj"
-      - "**.vbproj"
-      - "**.fsproj"
-      - "**.vcxproj"
-      - "**.sln"
-      - "**global.json"
-      - "**snippets.5000.json"
     branches: '*'
+    types: [opened, synchronize, reopened]
 
 env:
   DOTNET_INSTALLER_CHANNEL: '6.0'
@@ -30,8 +15,8 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  # This workflow contains a single job called "build snippets"
+  build-snippets:
     # The type of runner that the job will run on
     runs-on: windows-latest
 


### PR DESCRIPTION
See dotnet/docs#27056 for details.

In order for an action to be required for PRs to be merged, required actions must be triggered. If filters prevent them from starting, the action stays in the "pending" state forever.
