### PR TITLE
Snippets build system - update for vs 2022

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   DOTNET_INSTALLER_CHANNEL: '6.0'
-  DOTNET_DO_INSTALL: 'true'
+  DOTNET_DO_INSTALL: 'false'
   EnableNuGetPackageRestore: 'True'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "snippets-build"
   snippets-build:
     # The type of runner that the job will run on
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
         statuses: write
 
@@ -35,7 +35,7 @@ jobs:
         Invoke-WebRequest https://raw.githubusercontent.com/dotnet/install-scripts/master/src/dotnet-install.ps1 -OutFile dotnet-install.ps1
         echo "Installing dotnet version ${{ env.DOTNET_INSTALLER_CHANNEL }}"
         .\dotnet-install.ps1 -InstallDir "c:\program files\dotnet" -Channel "${{ env.DOTNET_INSTALLER_CHANNEL }}"
-    
+
     # Print dotnet info
     - name: Display .NET info
       run: |


### PR DESCRIPTION
## Summary

- Changed the runner to Windows Server 2022
- Updated path to VS developer command prompt to VS 2022
- Disabled custom .NET install flag, as 6.0 is already included.

@BillWagner @gewarren 
