### PR TITLE
Typo "MsBuild.exe"→"MSBuild.exe"

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-localizing-a-hybrid-application.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-localizing-a-hybrid-application.md
@@ -108,7 +108,7 @@ The Windows Forms Designer provides settings for enabling localization in a sate
 
 ## Assigning Resource Identifiers
 
-You can map your localizable content to resource assemblies by using resource identifiers. The MsBuild.exe application automatically assigns resource identifiers when you specify the `updateuid` option.
+You can map your localizable content to resource assemblies by using resource identifiers. The MSBuild.exe application automatically assigns resource identifiers when you specify the `updateuid` option.
 
 ### To assign resource identifiers
 


### PR DESCRIPTION
## Summary
Typo "MsBuild.exe"→"MSBuild.exe"

Describe your changes here.
https://docs.microsoft.com/en-us/dotnet/desktop/wpf/advanced/walkthrough-localizing-a-hybrid-application?view=netframeworkdesktop-4.8
https://github.com/dotnet/docs-desktop/blob/main/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-localizing-a-hybrid-application.md
#PingMSFTDocs

Fixes #Issue_Number (if available)
