### PR TITLE
Validation: Duplicate alt text and duplicate description error fixes.

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/additional-security-considerations-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/additional-security-considerations-in-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "Additional Security Considerations"
+description: Learn about the additional security measures that the .NET Framework offers in Windows Forms to restrict access to critical local resources.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Windows Forms, secure calls to Windows API"

--- a/dotnet-desktop-guide/framework/winforms/adjusting-the-size-and-scale-of-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/adjusting-the-size-and-scale-of-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "Adjust the size and scale"
+description: Learn how to adjust the size and scale of Windows Forms by reading the links provided in this topic.
 ms.date: "04/07/2017"
 helpviewer_keywords: 
   - "Windows Forms, changing size"

--- a/dotnet-desktop-guide/framework/winforms/advanced/about-gdi-managed-code.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/about-gdi-managed-code.md
@@ -1,5 +1,6 @@
 ---
 title: "About GDI+ Managed Code"
+description: Learn about GDI+ managed code, which provides two-dimensional vector graphics, imaging, and typography.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "GDI+, about GDI+"

--- a/dotnet-desktop-guide/framework/winforms/advanced/alpha-blending-lines-and-fills.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/alpha-blending-lines-and-fills.md
@@ -1,5 +1,6 @@
 ---
 title: "Alpha Blending Lines and Fills"
+description: Learn about how to use alpha blending to blend source and background color data associated with lines and fills in GDI+.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "lines [Windows Forms], adding transparency"

--- a/dotnet-desktop-guide/framework/winforms/advanced/antialiasing-with-lines-and-curves.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/antialiasing-with-lines-and-curves.md
@@ -1,6 +1,6 @@
 ---
 title: "Antialiasing with Lines and Curves"
-description: Learn how GDI+ works with the display driver software to apply antialiasing to pixels within lines and curves.
+description: Learn how to apply antialiasing to a line and curve in GDI+ for Windows Forms.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/antialiasing-with-lines-and-curves.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/antialiasing-with-lines-and-curves.md
@@ -1,5 +1,6 @@
 ---
 title: "Antialiasing with Lines and Curves"
+description: Learn how GDI+ works with the display driver software to apply antialiasing to pixels within lines and curves.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/application-settings-architecture.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/application-settings-architecture.md
@@ -1,5 +1,6 @@
 ---
 title: "Application Settings Architecture"
+description: Learn about the Application Settings architecture and the architecture's advanced features, such as grouped settings and settings keys.
 ms.date: "03/30/2017"
 dev_langs:
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/application-settings-attributes.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/application-settings-attributes.md
@@ -1,5 +1,6 @@
 ---
 title: "Application Settings Attributes"
+description: Learn how the Application Settings architecture provides many attributes that can be applied to the applications settings wrapper class or its properties.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "application settings [Windows Forms], attributes"

--- a/dotnet-desktop-guide/framework/winforms/advanced/application-settings-for-custom-controls.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/application-settings-for-custom-controls.md
@@ -1,5 +1,6 @@
 ---
 title: "Application Settings for Custom Controls"
+description: Learn how to use the Application Settings feature to make custom controls' settings persist properly.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "custom controls [Windows Forms], application settings"

--- a/dotnet-desktop-guide/framework/winforms/advanced/application-settings-for-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/application-settings-for-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "Application Settings"
+description: Learn about the Applications Settings feature of Windows Forms, which makes it easy to create, store, and maintain custom application and user preferences.
 ms.date: "04/07/2017"
 f1_keywords: 
   - "ClientApplicationSettings"

--- a/dotnet-desktop-guide/framework/winforms/advanced/bezier-splines-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/bezier-splines-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "B&#233;zier Splines in GDI+"
+description: Learn about Bézier splines, which are curves specified by two end points and two control points, in GDI+.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -13,7 +14,7 @@ ms.assetid: 5774ce1e-87d4-4bc7-88c4-4862052781b8
 # B&#233;zier Splines in GDI+
 A Bézier spline is a curve specified by four points: two end points (p1 and p2) and two control points (c1 and c2). The curve begins at p1 and ends at p2. The curve does not pass through the control points, but the control points act as magnets, pulling the curve in certain directions and influencing the way the curve bends. The following illustration shows a Bézier curve along with its endpoints and control points.  
   
- ![Bezier Splines](./media/aboutgdip02-art11a.gif "Aboutgdip02_art11a")  
+ ![Screenshot of a Bézier spline, which shows its endpoints and control points.](./media/aboutgdip02-art11a.gif "Aboutgdip02_art11a")  
   
  The curve starts at p1 and moves toward the control point c1. The tangent line to the curve at p1 is the line drawn from p1 to c1. The tangent line at the endpoint p2 is the line drawn from c2 to p2.  
   
@@ -25,7 +26,7 @@ A Bézier spline is a curve specified by four points: two end points (p1 and p2)
   
  The following illustration shows the curve, the control points, and two tangent lines.  
   
- ![Bezier Splines](./media/aboutgdip02-art12.gif "Aboutgdip02_art12")  
+ ![Screenshot of the Bézier spline, which shows the curve, the control points, and two tangent lines.](./media/aboutgdip02-art12.gif "Aboutgdip02_art12")  
   
  Bézier splines were originally developed by Pierre Bézier for design in the automotive industry. They have since proven to be useful in many types of computer-aided design and are also used to define the outlines of fonts. Bézier splines can yield a wide variety of shapes, some of which are shown in the following illustration.  
   

--- a/dotnet-desktop-guide/framework/winforms/advanced/bi-directional-support-for-windows-forms-applications.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/bi-directional-support-for-windows-forms-applications.md
@@ -1,5 +1,6 @@
 ---
 title: Bi-Directional Support
+description: Learn how to use Visual Studio to create Windows Forms-based applications that support bi-directional languages.
 ms.date: "09/30/2017"
 helpviewer_keywords:
   - "globalization [Windows Forms], bi-directional support in Windows"

--- a/dotnet-desktop-guide/framework/winforms/advanced/brushes-and-filled-shapes-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/brushes-and-filled-shapes-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Brushes and Filled Shapes in GDI+"
+description: Learn how GDI+ provides several brush classes for filling in the interiors of closed shapes, such as a rectangle or an ellipse.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -17,7 +18,7 @@ ms.assetid: e863e2a7-0294-4130-99b6-f1ea3201e7cd
 # Brushes and Filled Shapes in GDI+
 A closed shape, such as a rectangle or an ellipse, consists of an outline and an interior. The outline is drawn with a pen and the interior is filled with a brush. GDI+ provides several brush classes for filling the interiors of closed shapes: <xref:System.Drawing.SolidBrush>, <xref:System.Drawing.Drawing2D.HatchBrush>, <xref:System.Drawing.TextureBrush>, <xref:System.Drawing.Drawing2D.LinearGradientBrush>, and <xref:System.Drawing.Drawing2D.PathGradientBrush>. All of these classes inherit from the <xref:System.Drawing.Brush> class. The following illustration shows a rectangle filled with a solid brush and an ellipse filled with a hatch brush.  
   
- ![Filled Shapes](./media/aboutgdip02-art17.gif "Aboutgdip02_art17")  
+ ![Screenshot of a rectangle filled with a solid brush and an ellipse filled with a hatch brush.](./media/aboutgdip02-art17.gif "Aboutgdip02_art17")  
   
 ## Solid Brushes  
  To fill a closed shape, you need an instance of the <xref:System.Drawing.Graphics> class and a <xref:System.Drawing.Brush>. The instance of the <xref:System.Drawing.Graphics> class provides methods, such as <xref:System.Drawing.Graphics.FillRectangle%2A> and <xref:System.Drawing.Graphics.FillEllipse%2A>, and the <xref:System.Drawing.Brush> stores attributes of the fill, such as color and pattern. The <xref:System.Drawing.Brush> is passed as one of the arguments to the fill method. The following code example shows how to fill an ellipse with a solid red color.  
@@ -36,12 +37,12 @@ A closed shape, such as a rectangle or an ellipse, consists of an outline and an
   
  GDI+ provides more than 50 hatch styles; the three styles shown in the following illustration are <xref:System.Drawing.Drawing2D.HatchStyle.Horizontal>, <xref:System.Drawing.Drawing2D.HatchStyle.ForwardDiagonal>, and <xref:System.Drawing.Drawing2D.HatchStyle.Cross>.  
   
- ![Filled Shapes](./media/aboutgdip02-art18.gif "Aboutgdip02_art18")  
+ ![Screenshot of three ellipses that are filled with a horizontal hatch brush, forward diagonal hatch brush, and a cross hatch brush.](./media/aboutgdip02-art18.gif "Aboutgdip02_art18")  
   
 ## Texture Brushes  
  With a texture brush, you can fill a shape with a pattern stored in a bitmap. For example, suppose the following picture is stored in a disk file named `MyTexture.bmp`.  
   
- ![Filled Shape](./media/aboutgdip02-art19.gif "Aboutgdip02_Art19")  
+ ![Screenshot of the My Texture dot b m p file.](./media/aboutgdip02-art19.gif "Aboutgdip02_Art19")  
   
  The following code example shows how to fill an ellipse by repeating the picture stored in `MyTexture.bmp`.  
   
@@ -50,7 +51,7 @@ A closed shape, such as a rectangle or an ellipse, consists of an outline and an
   
  The following illustration shows the filled ellipse.  
   
- ![Filled Shape](./media/aboutgdip02-art20.gif "AboutGdip02_Art20")  
+ ![Screenshot of an ellipse that is filled with a texture brush.](./media/aboutgdip02-art20.gif "AboutGdip02_Art20")  
   
 ## Gradient Brushes  
  GDI+ provides two kinds of gradient brushes: linear and path. You can use a linear gradient brush to fill a shape with color that changes gradually as you move across the shape horizontally, vertically, or diagonally. The following code example shows how to fill an ellipse with a horizontal gradient brush that changes from blue to green as you move from the left edge of the ellipse to the right edge.  
@@ -60,15 +61,15 @@ A closed shape, such as a rectangle or an ellipse, consists of an outline and an
   
  The following illustration shows the filled ellipse.  
   
- ![Filled Shape](./media/aboutgdip02-art21.gif "AboutGdip02_Art21")  
+ ![Screenshot of an ellipse filled with a horizontal gradient brush.](./media/aboutgdip02-art21.gif "AboutGdip02_Art21")  
   
  A path gradient brush can be configured to change color as you move from the center of a shape toward the edge.  
   
- ![Filled Shape](./media/aboutgdip02-art22.gif "AboutGdip02_Art22")  
+ ![Screenshot of an ellipse filled with a path gradient brush.](./media/aboutgdip02-art22.gif "AboutGdip02_Art22")  
   
  Path gradient brushes are quite flexible. The gradient brush used to fill the triangle in the following illustration changes gradually from red at the center to each of three different colors at the vertices.  
   
- ![Filled Shape](./media/aboutgdip02-art23.gif "AboutGdip02_Art23")  
+ ![Screenshot of a triangle filled with a path gradient brush.](./media/aboutgdip02-art23.gif "AboutGdip02_Art23")  
   
 ## See also
 

--- a/dotnet-desktop-guide/framework/winforms/advanced/cardinal-splines-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/cardinal-splines-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Cardinal Splines in GDI+"
+description: Learn about cardinal splines, which are sequences of individual curves joined to form a larger curve, in GDI+.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/com-interop-by-displaying-a-windows-form-shadow.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/com-interop-by-displaying-a-windows-form-shadow.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Support COM Interop by Displaying a Windows Form with the ShowDialog Method"
+description: Learn how to support Common Object Model (COM) interoperability by displaying a Windows Form on a .NET Framework message loop with the ShowDialog method. 
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "COM [Windows Forms]"

--- a/dotnet-desktop-guide/framework/winforms/advanced/constructing-and-drawing-curves.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/constructing-and-drawing-curves.md
@@ -1,5 +1,6 @@
 ---
 title: "Constructing and Drawing Curves"
+description: Learn how GDI+ supports constructing and drawing ellipses, arcs, cardinal splines, and Bézier splines.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "drawing [Windows Forms], curves"

--- a/dotnet-desktop-guide/framework/winforms/advanced/constructing-and-drawing-paths.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/constructing-and-drawing-paths.md
@@ -1,5 +1,6 @@
 ---
 title: "Constructing and Drawing Paths"
+description: Learn how to construct and draw paths, which are sequences of graphics primitives that can be manipulated and drawn as a single unit.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "paths [Windows Forms], drawing"

--- a/dotnet-desktop-guide/framework/winforms/advanced/control-help-using-tooltips.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/control-help-using-tooltips.md
@@ -1,5 +1,6 @@
 ---
 title: "Control Help Using ToolTips"
+description: Learn how to use the System.Windows.Forms.ToolTip component to display a brief, specialized Help message for individual controls on Windows Forms.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Help [Windows Forms], tooltips for controls"

--- a/dotnet-desktop-guide/framework/winforms/advanced/control-help-using-tooltips.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/control-help-using-tooltips.md
@@ -1,6 +1,6 @@
 ---
 title: "Control Help Using ToolTips"
-description: Learn how to use the System.Windows.Forms.ToolTip component to display a brief, specialized Help message for individual controls on Windows Forms.
+description: Learn how to use the ToolTip component to display a brief, specialized Help message for individual controls on Windows Forms.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Help [Windows Forms], tooltips for controls"

--- a/dotnet-desktop-guide/framework/winforms/advanced/coordinate-systems-and-transformations.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/coordinate-systems-and-transformations.md
@@ -1,5 +1,6 @@
 ---
 title: "Coordinate Systems and Transformations"
+description: Learn how GDI+ provides world transformation and page transformation to transform the items that are drawn.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "transformations"

--- a/dotnet-desktop-guide/framework/winforms/advanced/cropping-and-scaling-images-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/cropping-and-scaling-images-in-gdi.md
@@ -1,6 +1,6 @@
 ---
 title: "Cropping and Scaling Images in GDI+"
-description: Learn how to use the System.Drawing.Graphics.DrawImage method of the System.Drawing.Graphics class to draw position vector images and raster images.
+description: Learn how to use the DrawImage method of the System.Drawing.Graphics class to draw and position vector images and raster images.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/cropping-and-scaling-images-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/cropping-and-scaling-images-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Cropping and Scaling Images in GDI+"
+description: Learn how to use the System.Drawing.Graphics.DrawImage method of the System.Drawing.Graphics class to draw position vector images and raster images.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/display-of-asian-characters-with-the-imemode-property.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/display-of-asian-characters-with-the-imemode-property.md
@@ -1,6 +1,6 @@
 ---
 title: "Display of Asian Characters with the ImeMode Property"
-description: Learn how the System.Windows.Forms.Control.ImeMode property is used by forms and controls to force a mode for an IME used for writing Asian language scripts.
+description: Learn how the Control's ImeMode property is used by forms and controls to force a mode for an IME used for writing Asian language scripts.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Asian languages [Windows Forms], displaying with ImeMode"

--- a/dotnet-desktop-guide/framework/winforms/advanced/display-of-asian-characters-with-the-imemode-property.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/display-of-asian-characters-with-the-imemode-property.md
@@ -1,5 +1,6 @@
 ---
 title: "Display of Asian Characters with the ImeMode Property"
+description: Learn how the System.Windows.Forms.Control.ImeMode property is used by forms and controls to force a mode for an IME used for writing Asian language scripts.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Asian languages [Windows Forms], displaying with ImeMode"

--- a/dotnet-desktop-guide/framework/winforms/advanced/double-buffered-graphics.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/double-buffered-graphics.md
@@ -1,6 +1,6 @@
 ---
 title: "Double Buffered Graphics"
-description: Learn how to use double buffered graphics in the .NET Framework to reduce flickering in programming graphics.
+description: Learn how to use double buffered graphics in Windows Forms to reduce flickering in programming graphics.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "double buffering"

--- a/dotnet-desktop-guide/framework/winforms/advanced/double-buffered-graphics.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/double-buffered-graphics.md
@@ -1,5 +1,6 @@
 ---
 title: "Double Buffered Graphics"
+description: Learn how to use double buffered graphics in the .NET Framework to reduce flickering in programming graphics.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "double buffering"

--- a/dotnet-desktop-guide/framework/winforms/advanced/drag-and-drop-operations-and-clipboard-support.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/drag-and-drop-operations-and-clipboard-support.md
@@ -1,5 +1,6 @@
 ---
 title: "Drag-and-Drop Operations and Clipboard Support"
+description: Learn how to enable user-drag-and-drop operations within Windows-based applications by handling a series of events.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "drag and drop [Windows Forms]"

--- a/dotnet-desktop-guide/framework/winforms/advanced/drawing-positioning-and-cloning-images-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/drawing-positioning-and-cloning-images-in-gdi.md
@@ -1,5 +1,5 @@
 ---
-title: "Drawing, Positioning, and Cloning Images in GDI+"
+title: "Draw, position, and clone Images in GDI+"
 description: Learn how to draw, position, and clone images in GDI+ using classes to load and display raster and vector images.
 ms.date: "03/30/2017"
 dev_langs: 

--- a/dotnet-desktop-guide/framework/winforms/advanced/drawing-positioning-and-cloning-images-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/drawing-positioning-and-cloning-images-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Drawing, Positioning, and Cloning Images in GDI+"
+description: Learn how to draw, position, and clone images in GDI+ using classes to load and display raster and vector images.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/effects-of-modifying-base-form-appearance.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/effects-of-modifying-base-form-appearance.md
@@ -1,5 +1,6 @@
 ---
 title: "Effects of Modifying a Base Form's Appearance"
+description: Learn how modifying a base form's appearance in a project can effect other forms within the project that inherit from the base form.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "parent forms [Windows Forms]"

--- a/dotnet-desktop-guide/framework/winforms/advanced/ellipses-and-arcs-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/ellipses-and-arcs-in-gdi.md
@@ -1,6 +1,6 @@
 ---
 title: "Ellipses and Arcs in GDI+"
-description: Learn how to draw ellipses and arcs using the System.Drawing.Graphics.DrawEllipse and System.Drawing.Graphics.DrawArc methods.
+description: Learn how to draw ellipses and arcs using the DrawEllipse and DrawArc methods in GDI+ with Windows Forms.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/ellipses-and-arcs-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/ellipses-and-arcs-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Ellipses and Arcs in GDI+"
+description: Learn how to draw ellipses and arcs using the System.Drawing.Graphics.DrawEllipse and System.Drawing.Graphics.DrawArc methods.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -19,7 +20,7 @@ You can easily draw ellipses and arcs using the <xref:System.Drawing.Graphics.Dr
 ## Drawing an Ellipse  
  To draw an ellipse, you need a <xref:System.Drawing.Graphics> object and a <xref:System.Drawing.Pen> object. The <xref:System.Drawing.Graphics> object provides the <xref:System.Drawing.Graphics.DrawEllipse%2A> method, and the <xref:System.Drawing.Pen> object stores attributes, such as width and color, of the line used to render the ellipse. The <xref:System.Drawing.Pen> object is passed as one of the arguments to the <xref:System.Drawing.Graphics.DrawEllipse%2A> method. The remaining arguments passed to the <xref:System.Drawing.Graphics.DrawEllipse%2A> method specify the bounding rectangle for the ellipse. The following illustration shows an ellipse along with its bounding rectangle.  
   
- ![Ellipses and arcs](./media/aboutgdip02-art05.gif "Aboutgdip02_art05")  
+ ![Screenshot of an ellipse surrounded by its bounding rectangle.](./media/aboutgdip02-art05.gif "Aboutgdip02_art05")  
   
  The following example draws an ellipse; the bounding rectangle has a width of 80, a height of 40, and an upper-left corner of (100, 50):  
   
@@ -39,7 +40,7 @@ You can easily draw ellipses and arcs using the <xref:System.Drawing.Graphics.Dr
   
  The following illustration shows the arc, the ellipse, and the bounding rectangle.  
   
- ![Ellipses and arcs](./media/aboutgdip02-art06.gif "Aboutgdip02_art06")  
+ ![Screenshot of an ellipse with an arc and its bounding rectangle.](./media/aboutgdip02-art06.gif "Aboutgdip02_art06")  
   
 ## See also
 

--- a/dotnet-desktop-guide/framework/winforms/advanced/global-and-local-transformations.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/global-and-local-transformations.md
@@ -1,5 +1,6 @@
 ---
 title: "Global and Local Transformations"
+description: Learn how global transformations apply to every item drawn by a System.Drawing.Graphics object and local transformations apply to a specific item.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -21,7 +22,7 @@ A global transformation is a transformation that applies to every item drawn by 
   
  The following illustration shows the matrices involved in the transformation.  
   
- ![Transformations](./media/aboutgdip05-art14.gif "AboutGdip05_art14")  
+ ![Illustration of the Scale, Translate, and Rotate matrices combining to form the global transformation.](./media/aboutgdip05-art14.gif "AboutGdip05_art14")  
   
 > [!NOTE]
 > In the preceding example, the ellipse is rotated about the origin of the coordinate system, which is at the upper-left corner of the client area. This produces a different result than rotating the ellipse about its own center.  
@@ -36,7 +37,7 @@ A global transformation is a transformation that applies to every item drawn by 
   
  Suppose you want a coordinate system that has its origin 200 pixels from the left edge of the client area and 150 pixels from the top of the client area. Furthermore, assume that you want the unit of measure to be the pixel, with the x-axis pointing to the right and the y-axis pointing up. The default coordinate system has the y-axis pointing down, so you need to perform a reflection across the horizontal axis. The following illustration shows the matrix of such a reflection.  
   
- ![Transformations](./media/aboutgdip05-art15.gif "AboutGdip05_art15")  
+ ![Illustration of a matrix that reflects across the horizontal axis.](./media/aboutgdip05-art15.gif "AboutGdip05_art15")  
   
  Next, assume you need to perform a translation 200 units to the right and 150 units down.  
   
@@ -52,7 +53,7 @@ A global transformation is a transformation that applies to every item drawn by 
   
  The following illustration shows the new coordinate system and the two rectangles.  
   
- ![Transformations](./media/aboutgdip05-art16.gif "AboutGdip05_art16")  
+ ![Illustration of the new coordinate system and the two rectangles.](./media/aboutgdip05-art16.gif "AboutGdip05_art16")  
   
 ## See also
 

--- a/dotnet-desktop-guide/framework/winforms/advanced/global-and-local-transformations.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/global-and-local-transformations.md
@@ -1,6 +1,6 @@
 ---
 title: "Global and Local Transformations"
-description: Learn how global transformations apply to every item drawn by a System.Drawing.Graphics object and local transformations apply to a specific item.
+description: Learn how global transformations apply to every item drawn by a Graphics object and local transformations apply to a specific item.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"


### PR DESCRIPTION
## Summary

Fixed:

- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)
- duplicate-descriptions errors (description is duplicated in another article/other articles)

This PR fixes 40 issues across 26 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.
