### PR TITLE
[BULK] validation: missing-description

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/group-controls-with-wf-panel-control-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/group-controls-with-wf-panel-control-using-the-designer.md
@@ -1,5 +1,6 @@
 ---
 title: Group Controls with Panel Control Using the Designer
+description: Learn how to group controls with the Windows Forms Panel Control by using the Designer and the reasons to group controls.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "Panel control [Windows Forms], grouping controls"

--- a/dotnet-desktop-guide/framework/winforms/controls/group-controls-with-wf-panel-control-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/group-controls-with-wf-panel-control-using-the-designer.md
@@ -1,6 +1,6 @@
 ---
 title: Group Controls with Panel Control Using the Designer
-description: Learn how to group controls with the Windows Forms Panel Control by using the Designer and the reasons to group controls.
+description: Learn how to group controls with the Windows Forms Panel control by using the Designer. Learn about the reasons to group controls.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "Panel control [Windows Forms], grouping controls"

--- a/dotnet-desktop-guide/framework/winforms/controls/handle-errors-that-occur-during-data-entry-in-the-datagrid.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/handle-errors-that-occur-during-data-entry-in-the-datagrid.md
@@ -1,5 +1,6 @@
 ---
 title: Handle Errors That Occur During Data Entry in DataGridView Control
+description: Use these examples to learn how to handle errors that occur during data entry in the Windows Forms DataGridView control.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/handling-errors-that-occur-during-data-entry-in-the-datagrid.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/handling-errors-that-occur-during-data-entry-in-the-datagrid.md
@@ -1,6 +1,6 @@
 ---
 title: "Walkthrough: Handling errors that occur during data entry in DataGridView control"
-description: Use this walkthrough to lean about handling errors that occur during data entry in the Windows Forms DataGridView control.
+description: Use this walkthrough to learn about handling errors that occur during data entry in the Windows Forms DataGridView control.
 ms.date: "03/30/2017"
 dev_langs:
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/handling-errors-that-occur-during-data-entry-in-the-datagrid.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/handling-errors-that-occur-during-data-entry-in-the-datagrid.md
@@ -1,5 +1,6 @@
 ---
 title: "Walkthrough: Handling errors that occur during data entry in DataGridView control"
+description: Use this walkthrough to lean about handling errors that occur during data entry in the Windows Forms DataGridView control.
 ms.date: "03/30/2017"
 dev_langs:
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/handling-user-input.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/handling-user-input.md
@@ -1,6 +1,6 @@
 ---
 title: "Handling User Input"
-description: Learn about the main keyboard and mouse events from System.Windows.Forms.Control. When handling an event, control authors should override the protected method.
+description: Learn about keyboard and mouse events from System.Windows.Forms.Control. When handling an event, control authors should override the protected method.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/handling-user-input.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/handling-user-input.md
@@ -1,5 +1,6 @@
 ---
 title: "Handling User Input"
+description: Learn about the main keyboard and mouse events from System.Windows.Forms.Control. When handling an event, control authors should override the protected method.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/handling-user-input.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/handling-user-input.md
@@ -1,6 +1,6 @@
 ---
 title: "Handling User Input"
-description: Learn about keyboard and mouse events from System.Windows.Forms.Control. When handling an event, control authors should override the protected method.
+description: Learn about keyboard and mouse events when handling an event, control authors should override the protected method.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-overview-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-overview-windows-forms.md
@@ -1,6 +1,6 @@
 ---
 title: "HelpProvider Component Overview"
-description: Learn how the Windows Forms HelpProvider component is used to associate an HTML Help 1.x Help file with your Windows application.
+description: Learn how the Windows Forms HelpProvider component is used to associate an HTML Help 1.x file with your Windows application.
 ms.date: "03/30/2017"
 f1_keywords: 
   - "HelpProvider"

--- a/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-overview-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-overview-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "HelpProvider Component Overview"
+description: Learn how the Windows Forms HelpProvider component is used to associate an HTML Help 1.x Help file with your Windows application.
 ms.date: "03/30/2017"
 f1_keywords: 
   - "HelpProvider"

--- a/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "HelpProvider Component"
+description: Learn how the Windows Forms HelpProvider component associates an HTML Help 1.x Help file with your Windows-based application.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "forms [Windows Forms], Help"

--- a/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/helpprovider-component-windows-forms.md
@@ -1,6 +1,6 @@
 ---
 title: "HelpProvider Component"
-description: Learn how the Windows Forms HelpProvider component associates an HTML Help 1.x Help file with your Windows-based application.
+description: Learn how the Windows Forms HelpProvider component associates an HTML Help 1.x file with your Windows-based application.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "forms [Windows Forms], Help"

--- a/dotnet-desktop-guide/framework/winforms/controls/hide-columns-in-the-datagrid-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/hide-columns-in-the-datagrid-using-the-designer.md
@@ -1,5 +1,6 @@
 ---
 title: Hide Columns in DataGridView Control Using the Designer
+description: Learn how to display only some of the columns that are available in a Windows Forms DataGridView control.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "Windows Forms, columns"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-access-objects-bound-to-windows-forms-datagridview-rows.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-access-objects-bound-to-windows-forms-datagridview-rows.md
@@ -1,5 +1,6 @@
 ---
 title: Access Objects Bound to DataGridView Rows
+description: Learn how to access objects bound to Windows Forms DataGridView rows to display a table of information stored in a collection of business objects.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-access-the-html-source-in-the-managed-html-document-object-model.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-access-the-html-source-in-the-managed-html-document-object-model.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Access the HTML Source in the Managed HTML Document Object Model"
+description: Learn how to access HTML source in the managed HTML Document Object Model. Properties return the HTML as it existed when it was first displayed.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-access-the-managed-html-document-object-model.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-access-the-managed-html-document-object-model.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Access the Managed HTML Document Object Model"
+description: Learn how you can access the managed HTML Document Object Model (DOM) from two types of applications.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-control-to-a-tab-page-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-control-to-a-tab-page-using-the-designer.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add a Control to a Tab Page Using the Designer"
+description: Learn how you can use the Windows Forms TabControl to display other controls in an organized fashion. This article shows how to display a picture on a tab page.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "TabPage control"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-control-to-a-tab-page.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-control-to-a-tab-page.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add a Control to a Tab Page"
+description: Learn how you can use the Windows Forms TabControl to display other controls in an organized fashion. This article shows how to add a button to the first tab.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-control-to-a-toolstripcontentpanel.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-control-to-a-toolstripcontentpanel.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add a Control to a ToolStripContentPanel"
+description: Use this code example to learn how you can programmatically add one or more controls to a ToolStripContentPanel.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-custom-place-to-a-file-dialog-box.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-custom-place-to-a-file-dialog-box.md
@@ -1,5 +1,6 @@
 ---
 title: "How To: Add a Custom Place to a File Dialog Box"
+description: The default open and save dialog boxes on Windows Vista have a custom places area. Learn how to add a custom place.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-custom-place-to-a-file-dialog-box.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-custom-place-to-a-file-dialog-box.md
@@ -1,6 +1,6 @@
 ---
 title: "How To: Add a Custom Place to a File Dialog Box"
-description: The default open and save dialog boxes on Windows Vista have a custom places area. Learn how to add a custom place.
+description: The default open and save dialog boxes on Windows have a custom places area. Learn how to add a custom place.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-toolstripcontainer-to-a-form.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-a-toolstripcontainer-to-a-form.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add a ToolStripContainer to a Form"
+description: Learn how you can programmatically add a ToolStripContainer to a Windows Form and populate it with controls.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-activex-controls-to-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-activex-controls-to-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: Add ActiveX Controls to forms
+description: Learn how to put ActiveX controls on Windows forms. While the Windows Forms Designer is optimized for Windows Forms controls, you can also use ActiveX controls.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "Windows Forms controls, ActiveX controls"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-activex-controls-to-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-activex-controls-to-windows-forms.md
@@ -1,6 +1,6 @@
 ---
 title: Add ActiveX Controls to forms
-description: Learn how to put ActiveX controls on Windows forms. While the Windows Forms Designer is optimized for Windows Forms controls, you can also use ActiveX controls.
+description: Learn how to put ActiveX controls on Windows forms. The Windows Forms Designer is optimized for Windows Forms controls, but you can use ActiveX controls.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "Windows Forms controls, ActiveX controls"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-and-remove-nodes-with-the-windows-forms-treeview-control.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-and-remove-nodes-with-the-windows-forms-treeview-control.md
@@ -1,5 +1,6 @@
 ---
 title: Add and Remove Nodes with TreeView Control
+description: The Windows Forms TreeView control stores the top-level nodes. Learn how to add and remove nodes with the Windows Forms TreeView control.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-buttons-to-a-toolbar-control-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-buttons-to-a-toolbar-control-using-the-designer.md
@@ -1,6 +1,6 @@
 ---
 title: "How to: Add Buttons to a ToolBar Control Using the Designer"
-description:  Learn how to add buttons to a ToolBar control by using the Designer. Adding buttons is an integral part of the using a ToolBar control.
+description: Learn how to add buttons to a ToolBar control by using the Designer. Adding buttons is an integral part of the using a ToolBar control.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "toolbars [Windows Forms], adding buttons"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-buttons-to-a-toolbar-control-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-buttons-to-a-toolbar-control-using-the-designer.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add Buttons to a ToolBar Control Using the Designer"
+description:  Learn how to add buttons to a ToolBar control by using the Designer. Adding buttons is an integral part of the using a ToolBar control.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "toolbars [Windows Forms], adding buttons"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-buttons-to-a-toolbar-control.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-buttons-to-a-toolbar-control.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add Buttons to a ToolBar Control"
+description: Learn how to add buttons to a ToolBar control, which is an integral part of the using the ToolBar control.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-columns-to-the-windows-forms-listview-control-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-columns-to-the-windows-forms-listview-control-using-the-designer.md
@@ -1,6 +1,6 @@
 ---
 title: Add Columns to ListView Control Using the Designer
-designer: Learn how to add columns to the Windows Forms ListView Control by using the Designer. The ListView control can display multiple columns for each list item.
+designer: Learn how to add columns to the Windows Forms ListView control by using the Designer. The ListView control can display multiple columns for each list item.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "ListView control [Windows Forms], adding column headers"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-columns-to-the-windows-forms-listview-control-using-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-columns-to-the-windows-forms-listview-control-using-the-designer.md
@@ -1,5 +1,6 @@
 ---
 title: Add Columns to ListView Control Using the Designer
+designer: Learn how to add columns to the Windows Forms ListView Control by using the Designer. The ListView control can display multiple columns for each list item.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "ListView control [Windows Forms], adding column headers"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-controls-without-a-user-interface-to-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-controls-without-a-user-interface-to-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: Add Controls Without a User Interface
+description: A nonvisual control provides functionality to your application. Learn how to add controls without a user interface to Windows Forms.
 ms.date: "03/30/2017"
 dev_langs:
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-enhancements-to-toolstripmenuitems.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-enhancements-to-toolstripmenuitems.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add Enhancements to ToolStripMenuItems"
+description: Learn how you can add enhancements to the usability of the MenuStrip and ContextMenuStrip controls.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-items-to-windows-forms-domainupdown-controls-programmatically.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-items-to-windows-forms-domainupdown-controls-programmatically.md
@@ -1,5 +1,6 @@
 ---
 title: Add Items to DomainUpDown Controls Programmatically
+description: Learn how to add items to Windows Forms DomainUpDown controls programmatically by using the DomainUpDownItemCollection.Add method.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-menu-items-to-a-contextmenustrip.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-menu-items-to-a-contextmenustrip.md
@@ -1,6 +1,6 @@
 ---
 title: "How to: Add Menu Items to a ContextMenuStrip"
-description: Learn how to add just one menu item or several items at a time to a ContextMenuStrip in Windows Formas.  
+description: Learn how to add just one menu item or several items at a time to a ContextMenuStrip control in Windows Forms.  
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-menu-items-to-a-contextmenustrip.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-menu-items-to-a-contextmenustrip.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add Menu Items to a ContextMenuStrip"
+description: Learn how to add just one menu item or several items at a time to a ContextMenuStrip in Windows Formas.  
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-or-remove-imagelist-images-with-the-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-or-remove-imagelist-images-with-the-designer.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add or Remove ImageList Images with the Designer"
+description: Learn about several ways that you can add images to an ImageList component, including by using the Properties window and using the smart tag.
 ms.date: "03/30/2017"
 helpviewer_keywords:
   - "ImageList component [Windows Forms], adding images"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-or-remove-images-with-the-windows-forms-imagelist-component.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-or-remove-images-with-the-windows-forms-imagelist-component.md
@@ -1,5 +1,6 @@
 ---
 title: Add or Remove Images with ImageList Component
+description: The Windows Forms ImageList component is typically populated with images before it is associated with a control. Learn to add and remove images later.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-panels-to-a-statusbar-control.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-panels-to-a-statusbar-control.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add Panels to a StatusBar Control"
+description: Learn how to add panels to a StatusBar control. The programmable area within a StatusBar control consists of instances of the StatusBarPanel class.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-search-capabilities-to-a-listview-control.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-search-capabilities-to-a-listview-control.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add Search Capabilities to a ListView Control"
+description: Learn how to offer a user search capabilities with a ListView control for use with a large list of items.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-tables-and-columns-to-the-windows-forms-datagrid-control.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-tables-and-columns-to-the-windows-forms-datagrid-control.md
@@ -1,5 +1,6 @@
 ---
 title: Add Tables and Columns to DataGrid Control
+description: Learn how to add tables and columns to a DataGrid control. You can restrict which columns from the table appear.
 ms.date: "03/30/2017"
 dev_langs:
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-toolstrip-items-dynamically.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-toolstrip-items-dynamically.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Add ToolStrip Items Dynamically"
+description: Learn how to dynamically add ToolStrip items to a ContextMenuStrip control and reuse the same control for three different controls on the form.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-add-toolstrip-items-dynamically.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-add-toolstrip-items-dynamically.md
@@ -1,6 +1,6 @@
 ---
 title: "How to: Add ToolStrip Items Dynamically"
-description: Learn how to dynamically add ToolStrip items to a ContextMenuStrip control and reuse the same control for three different controls on the form.
+description: Learn how to dynamically add ToolStrip items to a ContextMenuStrip control and reuse the same control for several different controls on the form.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"


### PR DESCRIPTION
## Summary

The Content & Learning team is fixing build validation errors on docs.microsoft.com. 

Add descriptions to 30 articles.
