### PR TITLE
Validation: fix missing descriptions #3

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/activate-function-wpf-unmanaged-api-reference.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/activate-function-wpf-unmanaged-api-reference.md
@@ -1,6 +1,6 @@
 ---
 title: "Activate Function - WPF unmanaged API reference"
-description: Learn about the Activate function, which is part of the Windows Presentation Foundation (WPF) Unmanaged API reference.
+description: Learn about the Activate function of the Windows Presentation Foundation (WPF) unmanaged API reference.
 titleSuffix: ""
 ms.date: "03/30/2017"
 dev_langs:

--- a/dotnet-desktop-guide/framework/wpf/advanced/cleartype-overview.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/cleartype-overview.md
@@ -1,5 +1,6 @@
 ---
 title: "ClearType Overview"
+description: Learn about Microsoft ClearType technology in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "typography [WPF], ClearType technology"

--- a/dotnet-desktop-guide/framework/wpf/advanced/cleartype-registry-settings.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/cleartype-registry-settings.md
@@ -1,5 +1,6 @@
 ---
 title: "ClearType Registry Settings"
+description: Learn about the Microsoft ClearType registry settings used by Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "ClearType [WPF], registry settings"

--- a/dotnet-desktop-guide/framework/wpf/advanced/code-behind-and-xaml-in-wpf.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/code-behind-and-xaml-in-wpf.md
@@ -1,5 +1,6 @@
 ---
 title: "Code-Behind and XAML"
+description: Learn about code-behind, which describes code that is joined with markup-defined objects when a XAML page is markup-compiled, in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "XAML [WPF], code-behind"

--- a/dotnet-desktop-guide/framework/wpf/advanced/code-behind-and-xaml-in-wpf.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/code-behind-and-xaml-in-wpf.md
@@ -1,6 +1,6 @@
 ---
 title: "Code-Behind and XAML"
-description: Learn about code-behind, which describes code that is joined with markup-defined objects when a XAML page is markup-compiled, in Windows Presentation Foundation (WPF).
+description: Learn about code-behind, which describes code that is joined with markup-defined objects when an XAML page is markup-compiled, in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "XAML [WPF], code-behind"

--- a/dotnet-desktop-guide/framework/wpf/advanced/collecting-ink.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/collecting-ink.md
@@ -1,5 +1,6 @@
 ---
 title: Collect digital ink
+description: Learn about methods for collecting digital ink in Windows Presentation Foundation (WPF).
 ms.date: 08/15/2018
 dev_langs:
   - "csharp"

--- a/dotnet-desktop-guide/framework/wpf/advanced/collection-type-dependency-properties.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/collection-type-dependency-properties.md
@@ -1,5 +1,6 @@
 ---
 title: "Collection-Type Dependency Properties"
+description: Learn how to implement and initialize collection-type dependency properties in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/wpf/advanced/colorconvertedbitmap-markup-extension.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/colorconvertedbitmap-markup-extension.md
@@ -1,5 +1,6 @@
 ---
 title: "ColorConvertedBitmap Markup Extension"
+description: Learn about the ColorConvertedBitmap markup XAML extension of Windows Presentation Foundation (WPF).
 ms.date: "01/17/2022"
 ms.custom: devdivchpfy22
 helpviewer_keywords: 

--- a/dotnet-desktop-guide/framework/wpf/advanced/componentresourcekey-markup-extension.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/componentresourcekey-markup-extension.md
@@ -1,5 +1,6 @@
 ---
 title: "ComponentResourceKey Markup Extension"
+description: Learn about the ComponentResourceKey markup XAML extension of Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 ms.custom: devdivchpfy22
 f1_keywords: 

--- a/dotnet-desktop-guide/framework/wpf/advanced/createidispatchstaforwarder-function-wpf-unmanaged-api-reference.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/createidispatchstaforwarder-function-wpf-unmanaged-api-reference.md
@@ -1,5 +1,6 @@
 ---
 title: "CreateIDispatchSTAForwarder Function - WPF unmanaged API reference"
+description: Learn about the CreateIDispatchSTAForwarder function of the Windows Presentation Foundation (WPF) unmanaged API reference.
 titleSuffix: ""
 ms.date: "03/30/2017"
 dev_langs: 


### PR DESCRIPTION
**Global effort to fix validation errors**

The Content & Learning team is fixing build validation errors on docs.microsoft.com. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only build validation fixes and does not change other content. I’d very much appreciate your timely review and feedback on these changes I’ve suggested. Thanks!