### PR TITLE
Validation: fix missing descriptions #4

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/creating-an-ink-input-control.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/creating-an-ink-input-control.md
@@ -1,5 +1,6 @@
 ---
 title: "Creating an Ink Input Control"
+description: Learn how to create a digital ink input control in a Windows Presentation Foundation (WPF) application.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "ink strokes [WPF], managing"

--- a/dotnet-desktop-guide/framework/wpf/advanced/custom-rendering-ink.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/custom-rendering-ink.md
@@ -1,5 +1,6 @@
 ---
 title: "Custom Rendering Ink"
+description: Learn how to customize digital ink rendering in a Windows Presentation Foundation (WPF) application.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/wpf/advanced/data-and-data-objects.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/data-and-data-objects.md
@@ -1,6 +1,6 @@
 ---
 title: "Data and Data Objects"
-description: Learn how to use data with data objects in a Windows Presentation Foundation (WPF) application.
+description: Learn about data objects and how they handle data in a Windows Presentation Foundation (WPF) application.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/wpf/advanced/data-and-data-objects.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/data-and-data-objects.md
@@ -1,5 +1,6 @@
 ---
 title: "Data and Data Objects"
+description: Learn how to use data with data objects in a Windows Presentation Foundation (WPF) application.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/wpf/advanced/datetime-xaml-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/datetime-xaml-syntax.md
@@ -1,6 +1,6 @@
 ---
 title: "DateTime XAML Syntax"
-description: Learn about DateTime XAML syntax and when to use this syntax in Windows Presentation Foundation (WPF).
+description: Learn about DateTime Extensible Application Markup Language (XAML) syntax and when to use this syntax in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "DateTime XAML syntax [WPF], strings for"

--- a/dotnet-desktop-guide/framework/wpf/advanced/datetime-xaml-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/datetime-xaml-syntax.md
@@ -1,5 +1,6 @@
 ---
 title: "DateTime XAML Syntax"
+description: Learn about DateTime XAML syntax in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "DateTime XAML syntax [WPF], strings for"

--- a/dotnet-desktop-guide/framework/wpf/advanced/datetime-xaml-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/datetime-xaml-syntax.md
@@ -1,6 +1,6 @@
 ---
 title: "DateTime XAML Syntax"
-description: Learn about DateTime XAML syntax in Windows Presentation Foundation (WPF).
+description: Learn about DateTime XAML syntax and when to use this syntax in Windows Presentation Foundation (WPF).
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "DateTime XAML syntax [WPF], strings for"

--- a/dotnet-desktop-guide/framework/wpf/advanced/deactivate-function-wpf-unmanaged-api-reference.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/deactivate-function-wpf-unmanaged-api-reference.md
@@ -1,5 +1,6 @@
 ---
 title: "Deactivate Function - WPF unmanaged API reference"
+description: Learn about the Deactivate function of the Windows Presentation Foundation (WPF) unmanaged API reference.
 titleSuffix: ""
 ms.date: "03/30/2017"
 dev_langs: 

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-callbacks-and-validation.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-callbacks-and-validation.md
@@ -1,5 +1,6 @@
 ---
 title: "Dependency Property Callbacks and Validation"
+description: Learn about dependency property callbacks and validation in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-metadata.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-metadata.md
@@ -1,5 +1,6 @@
 ---
 title: "Dependency Property Metadata"
+description: Learn about dependency property metadata in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "APIs [WPF], metadata"

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-metadata.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: "Dependency Property Metadata"
-description: Learn about dependency property metadata in Windows Presentation Foundation (WPF) applications.
+description: Learn about dependency property metadata, and how to use it, in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "APIs [WPF], metadata"

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-security.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-security.md
@@ -1,6 +1,6 @@
 ---
 title: "Dependency Property Security"
-description: Learn about dependency property security in Windows Presentation Foundation (WPF) applications.
+description: Learn about security considerations for dependency properties in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "wrappers [WPF], access"

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-security.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-security.md
@@ -1,5 +1,6 @@
 ---
 title: "Dependency Property Security"
+description: Learn about dependency property security in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "wrappers [WPF], access"

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-value-precedence.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-value-precedence.md
@@ -1,5 +1,6 @@
 ---
 title: "Dependency Property Value Precedence"
+description: Learn about dependency property value precedence in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "dependency properties [WPF], classes as owners"

--- a/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-value-precedence.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/dependency-property-value-precedence.md
@@ -1,6 +1,6 @@
 ---
 title: "Dependency Property Value Precedence"
-description: Learn about dependency property value precedence in Windows Presentation Foundation (WPF) applications.
+description: Learn about value precedence considerations for dependency properties in Windows Presentation Foundation (WPF) applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "dependency properties [WPF], classes as owners"


### PR DESCRIPTION
**Global effort to fix validation errors**

The Content & Learning team is fixing build validation errors on docs.microsoft.com. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only build validation fixes and does not change other content. I’d very much appreciate your timely review and feedback on these changes I’ve suggested. Thanks!