### PR TITLE
Validation: Duplicate alt text and missing description error fixes.

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/advanced/how-to-use-a-pen-to-draw-rectangles.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/how-to-use-a-pen-to-draw-rectangles.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Use a Pen to Draw Rectangles"
+description: Learn how to draw rectangles using a System.Drawing.Graphics object and a System.Drawing.Pen object.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/how-to-use-clipping-with-a-region.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/how-to-use-clipping-with-a-region.md
@@ -1,5 +1,6 @@
 ---
 title: "How to: Use Clipping with a Region"
+description: Learn how to use the clip region property of the System.Drawing.Graphics class by using a code example that constructs a clip region based on a single polygon.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/images-bitmaps-and-metafiles.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/images-bitmaps-and-metafiles.md
@@ -1,5 +1,6 @@
 ---
 title: "Images, Bitmaps, and Metafiles"
+description: Learn about the Image class, as well as the Bitmap class and the System.Drawing.Imaging.Metafile class, which both inherit from the Image class.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "metafiles [Windows Forms], about metafiles"

--- a/dotnet-desktop-guide/framework/winforms/advanced/index.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/index.md
@@ -1,5 +1,6 @@
 ---
 title: Enhance apps
+description: Learn more about enhancing Windows Form applications to meet specific user needs with a selection of topics and tutorials.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Windows Forms, enhancing"

--- a/dotnet-desktop-guide/framework/winforms/advanced/integrating-user-help-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/integrating-user-help-in-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "Integrating User Help"
+description: Learn more about integrating Help for user assistance in Windows Forms applications with a selection of topics and tutorials.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Help [Windows Forms], Windows Forms (using designer)"

--- a/dotnet-desktop-guide/framework/winforms/advanced/international-fonts-in-windows-forms-and-controls.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/international-fonts-in-windows-forms-and-controls.md
@@ -1,5 +1,6 @@
 ---
 title: International fonts in forms and controls
+description: Learn about using font fallback as the recommended method for selecting International fonts in Windows Forms and controls.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "fonts [Windows Forms], international"

--- a/dotnet-desktop-guide/framework/winforms/advanced/international-fonts-in-windows-forms-and-controls.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/international-fonts-in-windows-forms-and-controls.md
@@ -1,6 +1,6 @@
 ---
 title: International fonts in forms and controls
-description: Learn about using font fallback as the recommended method for selecting International fonts in Windows Forms and controls.
+description: Learn about using font fallback as the recommended method for selecting international fonts in Windows Forms and controls.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "fonts [Windows Forms], international"

--- a/dotnet-desktop-guide/framework/winforms/advanced/lines-curves-and-shapes.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/lines-curves-and-shapes.md
@@ -1,5 +1,6 @@
 ---
 title: "Lines, Curves, and Shapes"
+description: Learn more about using the vector graphics portion of GDI+ to draw lines, draw curves, and draw and fill shapes with a selection of topics and tutorials.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "shapes [Windows Forms], filling"

--- a/dotnet-desktop-guide/framework/winforms/advanced/managing-the-state-of-a-graphics-object.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/managing-the-state-of-a-graphics-object.md
@@ -1,5 +1,6 @@
 ---
 title: "Managing the State of a Graphics Object"
+description: Learn more about managing the state of a System.Drawing.Graphics object, setting its properties, and calling its methods.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/metafiles-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/metafiles-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Metafiles in GDI+"
+description: Learn how GDI+ provides the System.Drawing.Imaging.Metafile class to record and display metafiles. A metafile is also called a vector image.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/networking-in-windows-forms-applications.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/networking-in-windows-forms-applications.md
@@ -1,5 +1,6 @@
 ---
 title: Networking
+description: Learn about how the .NET Framework provides classes for network functionality that can be built into Windows Forms applications.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "networking [Windows Forms], Windows Forms"

--- a/dotnet-desktop-guide/framework/winforms/advanced/open-and-closed-curves-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/open-and-closed-curves-in-gdi.md
@@ -1,6 +1,6 @@
 ---
 title: "Open and Closed Curves in GDI+"
-description: Learn more about how GDI+ handles open and closed curves with the System.Drawing.Graphics class and its methods.
+description: Learn more about how GDI+ can create open and closed curves with the Graphics class and its methods.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/open-and-closed-curves-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/open-and-closed-curves-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Open and Closed Curves in GDI+"
+description: Learn more about how GDI+ handles open and closed curves with the System.Drawing.Graphics class and its methods.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -14,7 +15,7 @@ ms.assetid: 08d2cc9a-dc9d-4eed-bcbb-2c8e2ca5d3ae
 # Open and Closed Curves in GDI+
 The following illustration shows two curves: one open and one closed.  
   
- ![Open & Closed curves](./media/aboutgdip02-art24.gif "Aboutgdip02_art24")  
+ ![Screenshot of one open curve and one closed curve.](./media/aboutgdip02-art24.gif "Aboutgdip02_art24")  
   
 ## Managed Interface for Curves  
  Closed curves have an interior and therefore can be filled with a brush. The <xref:System.Drawing.Graphics> class in GDI+ provides the following methods for filling closed shapes and curves: <xref:System.Drawing.Graphics.FillRectangle%2A>, <xref:System.Drawing.Graphics.FillEllipse%2A>, <xref:System.Drawing.Graphics.FillPie%2A>, <xref:System.Drawing.Graphics.FillPolygon%2A>, <xref:System.Drawing.Graphics.FillClosedCurve%2A>, <xref:System.Drawing.Graphics.FillPath%2A>, and <xref:System.Drawing.Graphics.FillRegion%2A>. Whenever you call one of these methods, you must pass one of the specific brush types (<xref:System.Drawing.SolidBrush>, <xref:System.Drawing.Drawing2D.HatchBrush>, <xref:System.Drawing.TextureBrush>, <xref:System.Drawing.Drawing2D.LinearGradientBrush>, or <xref:System.Drawing.Drawing2D.PathGradientBrush>) as an argument.  
@@ -26,7 +27,7 @@ The following illustration shows two curves: one open and one closed.
   
  The following illustration shows the arc and the filled pie.  
   
- ![Open & Closed curves](./media/aboutgdip02-art25.gif "Aboutgdip02_art25")  
+ ![Screenshot of an arc and the filled pie.](./media/aboutgdip02-art25.gif "Aboutgdip02_art25")  
   
  The <xref:System.Drawing.Graphics.FillClosedCurve%2A> method is a companion to the <xref:System.Drawing.Graphics.DrawClosedCurve%2A> method. Both methods automatically close the curve by connecting the ending point to the starting point. The following example draws a curve that passes through (0, 0), (60, 20), and (40, 50). Then, the curve is automatically closed by connecting (40, 50) to the starting point (0, 0), and the interior is filled with a solid color.  
   

--- a/dotnet-desktop-guide/framework/winforms/advanced/overview-of-graphics.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/overview-of-graphics.md
@@ -1,5 +1,6 @@
 ---
 title: "Overview of Graphics"
+description: Learn how the GDI+ application programming interface (API) forms the subsystem of the Microsoft Windows OS and displays information on screens and printers.
 ms.date: "03/30/2017"
 ms.topic: overview
 helpviewer_keywords: 

--- a/dotnet-desktop-guide/framework/winforms/advanced/overview-of-graphics.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/overview-of-graphics.md
@@ -1,6 +1,6 @@
 ---
 title: "Overview of Graphics"
-description: Learn how the GDI+ application programming interface (API) forms the subsystem of the Microsoft Windows OS and displays information on screens and printers.
+description: Learn how the GDI+ application programming interface (API) forms the subsystem of the Microsoft Windows operating system, which displays information on screens and printers.
 ms.date: "03/30/2017"
 ms.topic: overview
 helpviewer_keywords: 

--- a/dotnet-desktop-guide/framework/winforms/advanced/pens-lines-and-rectangles-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/pens-lines-and-rectangles-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Pens, Lines, and Rectangles in GDI+"
+description: Learn how to draw lines and rectangles and construct a pen by using objects and methods in GDI+ that store attributes, such as line color, width, and style.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/polygons-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/polygons-in-gdi.md
@@ -1,6 +1,6 @@
 ---
 title: "Polygons in GDI+"
-description: Learn about how to draw a polygon in GDI+ using a System.Drawing.Graphics object, a System.Drawing.Pen object, and an array of System.Drawing.Point objects.
+description: Learn about how to draw a polygon in GDI+ using a Graphics object, a Pen object, and an array of objects.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/polygons-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/polygons-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Polygons in GDI+"
+description: Learn about how to draw a polygon in GDI+ using a System.Drawing.Graphics object, a System.Drawing.Pen object, and an array of System.Drawing.Point objects.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/power-management-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/power-management-in-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: "Power Management"
+description: Learn about how Windows Forms applications can use the power management features in the Windows operating system to monitor a computer's power status and take action. 
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/power-management-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/power-management-in-windows-forms.md
@@ -1,6 +1,6 @@
 ---
 title: "Power Management"
-description: Learn about how Windows Forms applications can use the power management features in the Windows operating system to monitor a computer's power status and take action. 
+description: Learn how Windows Forms applications can use power management features in the Windows operating system to monitor a computer's power status and take action.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/properties-on-windows-forms-controls-that-support-accessibility-guidelines.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/properties-on-windows-forms-controls-that-support-accessibility-guidelines.md
@@ -1,5 +1,6 @@
 ---
 title: Accessibility properties on controls
+description: Learn about properties on Windows Forms controls that support accessibility guidelines, such as exposing the keyboard focus and the screen elements.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "Windows Forms, accessibility properties of controls"

--- a/dotnet-desktop-guide/framework/winforms/advanced/recoloring-images.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/recoloring-images.md
@@ -1,5 +1,6 @@
 ---
 title: "Recoloring Images"
+description: Learn more about various ways to recolor images in GDI+ with a selection of topics and tutorials that provide examples.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "images [Windows Forms], recoloring"

--- a/dotnet-desktop-guide/framework/winforms/advanced/regions-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/regions-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Regions in GDI+"
+description: A region is a portion of the display area of an output device. Learn more about regions in GDI+ and how they are used.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -13,7 +14,7 @@ ms.assetid: 52184f9b-16dd-4bbd-85be-029112644ceb
 # Regions in GDI+
 A region is a portion of the display area of an output device. Regions can be simple (a single rectangle) or complex (a combination of polygons and closed curves). The following illustration shows two regions: one constructed from a rectangle, and the other constructed from a path.  
   
- ![Regions](./media/aboutgdip02-art27.gif "AboutGdip02_Art27")  
+ ![Screenshot of a region constructed from a rectangle and a screenshot of a region constructed from a path.](./media/aboutgdip02-art27.gif "AboutGdip02_Art27")  
   
 ## Using Regions  
  Regions are often used for clipping and hit testing. Clipping involves restricting drawing to a certain region of the display area, usually the portion that needs to be updated. Hit testing involves checking to determine whether the cursor is in a certain region of the screen when a mouse button is pressed.  
@@ -22,11 +23,11 @@ A region is a portion of the display area of an output device. Regions can be si
   
  The intersection of two regions is the set of all points belonging to both regions. The union is the set of all points belonging to one or the other or both regions. The complement of a region is the set of all points that are not in the region. The following illustration shows the intersection and union of the two regions shown in the preceding illustration.  
   
- ![Regions](./media/aboutgdip02-art28.gif "AboutGdip02_Art28")  
+ ![Screenshot of an intersection and a union of the two regions from the preceding illustration.](./media/aboutgdip02-art28.gif "AboutGdip02_Art28")  
   
  The <xref:System.Drawing.Region.Xor%2A> method, applied to a pair of regions, produces a region that contains all points that belong to one region or the other, but not both. The <xref:System.Drawing.Region.Exclude%2A> method, applied to a pair of regions, produces a region that contains all points in the first region that are not in the second region. The following illustration shows the regions that result from applying the <xref:System.Drawing.Region.Xor%2A> and <xref:System.Drawing.Region.Exclude%2A> methods to the two regions shown at the beginning of this topic.  
   
- ![Regions](./media/aboutgdip02-art29.gif "AboutGdip02_Art29")  
+ ![Screenshot of the Xor method results and the Exclude method results applied to the two regions from the preceding illustration.](./media/aboutgdip02-art29.gif "AboutGdip02_Art29")  
   
  To fill a region, you need a <xref:System.Drawing.Graphics> object, a <xref:System.Drawing.Brush> object, and a <xref:System.Drawing.Region> object. The <xref:System.Drawing.Graphics> object provides the <xref:System.Drawing.Graphics.FillRegion%2A> method, and the <xref:System.Drawing.Brush> object stores attributes of the fill, such as color or pattern. The following example fills a region with a solid color.  
   

--- a/dotnet-desktop-guide/framework/winforms/advanced/restricting-the-drawing-surface-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/restricting-the-drawing-surface-in-gdi.md
@@ -1,5 +1,6 @@
 ---
 title: "Restricting the Drawing Surface in GDI+"
+description: Learn how to restrict the drawing surface in GDI+ using regions, which can be constructed from paths and contain the outlines of strings.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -13,12 +14,12 @@ ms.assetid: 8b5f71d9-d2f0-4540-9c41-740f90fd4c26
 # Restricting the Drawing Surface in GDI+
 Clipping involves restricting drawing to a certain rectangle or region. The following illustration shows the string "Hello" clipped to a heart-shaped region.  
   
- ![Restricted Drawing Surface](./media/aboutgdip02-art30.gif "AboutGdip02_Art30")  
+ ![Screenshot of a heart-shaped region with the text string Hello inside the heart.](./media/aboutgdip02-art30.gif "AboutGdip02_Art30")  
   
 ## Clipping with Regions  
  Regions can be constructed from paths, and paths can contain the outlines of strings, so you can use outlined text for clipping. The following illustration shows a set of concentric ellipses clipped to the interior of a string of text.  
   
- ![Restricted Drawing Surface](./media/aboutgdip02-art31.gif "AboutGdip02_Art31")  
+ ![Screenshot of the text string Hello with a set of concentric ellipses clipped to the interior of the text.](./media/aboutgdip02-art31.gif "AboutGdip02_Art31")  
   
  To draw with clipping, create a <xref:System.Drawing.Graphics> object, set its <xref:System.Drawing.Graphics.Clip%2A> property, and then call the drawing methods of that same <xref:System.Drawing.Graphics> object:  
   

--- a/dotnet-desktop-guide/framework/winforms/advanced/restricting-the-drawing-surface-in-gdi.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/restricting-the-drawing-surface-in-gdi.md
@@ -1,6 +1,6 @@
 ---
 title: "Restricting the Drawing Surface in GDI+"
-description: Learn how to restrict the drawing surface in GDI+ using regions, which can be constructed from paths and contain the outlines of strings.
+description: Learn how to restrict the drawing surface in GDI+ using clipping regions in Windows Forms.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/structure-of-the-graphics-interface.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/structure-of-the-graphics-interface.md
@@ -1,5 +1,6 @@
 ---
 title: "Structure of the Graphics Interface"
+description: Learn about the structure of the Graphics Interface, which includes important classes like the System.Drawing.Graphics class.
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "GDI+, using managed interface"

--- a/dotnet-desktop-guide/framework/winforms/advanced/system-information-and-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/system-information-and-windows-forms.md
@@ -1,5 +1,6 @@
 ---
 title: System Information
+description: Learn how to incorporate computer system information into Windows Forms applications using the System.Windows.Forms.SystemInformation class.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"

--- a/dotnet-desktop-guide/framework/winforms/advanced/three-categories-of-graphics-services.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/three-categories-of-graphics-services.md
@@ -1,5 +1,6 @@
 ---
 title: "Three Categories of Graphics Services"
+description: "Learn about the three categories of graphics services: two-dimensional (2-D) vector graphics, imaging, and typography."
 ms.date: "03/30/2017"
 helpviewer_keywords: 
   - "imaging"

--- a/dotnet-desktop-guide/framework/winforms/advanced/types-of-bitmaps.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/types-of-bitmaps.md
@@ -37,7 +37,7 @@ A bitmap is an array of bits that specify the color of each pixel in a rectangul
   
  Disk files that store bitmaps usually contain one or more information blocks that store information such as the number of bits per pixel, number of pixels in each row, and number of rows in the array. Such a file might also contain a color table (sometimes called a color palette). A color table maps numbers in the bitmap to specific colors. The following illustration shows an enlarged image along with its bitmap and color table. Each pixel is represented by a 4-bit number, so there are 2^4 = 16 colors in the color table. Each color in the table is represented by a 24-bit number: 8 bits for red, 8 bits for green, and 8 bits for blue. The numbers are shown in hexadecimal (base 16) form: A = 10, B = 11, C = 12, D = 13, E = 14, F = 15.  
   
- ![Bitmap sample](./media/aboutgdip03-art01.gif "AboutGdip03_Art01")  
+ ![Screenshot of an enlarged image with its bitmap and color table.](./media/aboutgdip03-art01.gif "AboutGdip03_Art01")  
   
  Look at the pixel in row 3, column 5 of the image. The corresponding number in the bitmap is 1. The color table tells us that 1 represents the color red so the pixel is red. All the entries in the top row of the bitmap are 3. The color table tells us that 3 represents blue, so all the pixels in the top row of the image are blue.  
   
@@ -46,7 +46,7 @@ A bitmap is an array of bits that specify the color of each pixel in a rectangul
   
  A bitmap that stores indexes into a color table is called a palette-indexed bitmap. Some bitmaps have no need for a color table. For example, if a bitmap uses 24 bits per pixel, that bitmap can store the colors themselves rather than indexes into a color table. The following illustration shows a bitmap that stores colors directly (24 bits per pixel) rather than using a color table. The illustration also shows an enlarged view of the corresponding image. In the bitmap, FFFFFF represents white, FF0000 represents red, 00FF00 represents green, and 0000FF represents blue.  
   
- ![Bitmap sample](./media/aboutgdip03-art02.gif "AboutGdip03_Art02")  
+ ![Screenshot of a bitmap that stores colors directly with an enlarged view of the corresponding image.](./media/aboutgdip03-art02.gif "AboutGdip03_Art02")  
   
 ## Graphics File Formats  
  There are many standard formats for saving bitmaps in disk files. GDI+ supports the graphics file formats described in the following paragraphs.  


### PR DESCRIPTION
## Summary

Fixed:

- description-missing errors (description metadata missing in articles)
- image-alt-text-duplicated errors (duplicate alt text descriptions within an article)

This PR fixes 31 issues across 23 files and is part of ongoing Validation cleanup efforts. No other content has been edited or added.