### PR TITLE
Fix Winforms High DPI sample configuration

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/high-dpi-support-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/high-dpi-support-in-windows-forms.md
@@ -46,14 +46,14 @@ In addition, to configure high DPI support in your Windows Forms application, yo
   Windows Forms introduces a new [`<System.Windows.Forms.ApplicationConfigurationSection>`](/dotnet/framework/configure-apps/file-schema/winforms/index) element to support new features and customizations added starting with the .NET Framework 4.7. To take advantage of the new features that support high DPI, add the following to your application configuration file.
 
   ```xml
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+  <configuration>
     <!-- ... other xml settings ... -->
 
     <System.Windows.Forms.ApplicationConfigurationSection>
       <add key="DpiAwareness" value="PerMonitorV2" />
     </System.Windows.Forms.ApplicationConfigurationSection>
 
-  </compatibility>
+  </configuration>
   ```
 
   > [!IMPORTANT]


### PR DESCRIPTION
## Summary

We got pinged on the WebView2 repo about a bug in the HighDPI sample that was confusing our users:
https://github.com/MicrosoftEdge/WebView2Feedback/issues/1700#issuecomment-1221610180

Here's the related issue on the dotnet/docs-desktop repo:
https://github.com/dotnet/docs-desktop/issues/1485

The fix is to change the <compatibility> tag with the correct <configuration> tag. The correct tags are demonstrated on this page:
https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/winforms/

Fixes #1485
