### PR TITLE
Add WFDEV warning reference

### DIFF
--- a/dotnet-desktop-guide/net/winforms/toc.yml
+++ b/dotnet-desktop-guide/net/winforms/toc.yml
@@ -125,4 +125,15 @@ items:
       href: data/how-to-create-control-binding.md
     - name: Synchronize multiple controls
       href: data/how-to-synchronize-multiple-controls.md
+- name: WFDEV warnings
+  items:
+  - name: Overview
+    href: wfdev-diagnostics/obsoletions-overview.md
+    displayName: wfdev warnings
+  - name: WFDEV001
+    href: wfdev-diagnostics/wfdev001.md
+  - name: WFDEV002
+    href: wfdev-diagnostics/wfdev002.md
+  - name: WFDEV003
+    href: wfdev-diagnostics/wfdev003.md
  

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
@@ -17,7 +17,7 @@ The following table provides an index to the `WFDEVXXX` obsoletions and warnings
 
 | Diagnostic ID | Warning or error | Description |
 | - | - |
-| [WFDEV001](wfdev001.md) | Warning | Casting to/from <xref:System.IntPtr> is unsafe, use `WParamInternal`, `LParamInternal`, or `ResultInternal` instead. |
+| [WFDEV001](wfdev001.md) | Warning | Casting to/from <xref:System.IntPtr> is unsafe. Use `WParamInternal`, `LParamInternal`, or `ResultInternal` instead. |
 | [WFDEV002](wfdev001.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> controls. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
 | [WFDEV003](wfdev001.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> items. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
 

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
@@ -1,0 +1,64 @@
+---
+title: Obsolete Windows Forms features in .NET 7+
+titleSuffix: ""
+description: Learn about Windows Forms APIs that are marked as obsolete in .NET 7 and later versions that produce WFDEV compiler warnings.
+ms.date: 09/09/2022
+---
+
+# Obsolete Windows Forms features in .NET 7+
+
+Starting in .NET 7, some Windows Forms APIs are marked as obsolete (or otherwise produce a warning) with custom diagnostic IDs of the format `WFDEVXXX`.
+
+If you encounter build warnings or errors due to usage of an obsolete API, follow the specific guidance provided for the diagnostic ID listed in the [Reference](#reference) section. Warnings or errors for these obsoletions *can't* be suppressed using the [standard diagnostic ID (CS0618)](../../csharp/language-reference/compiler-messages/cs0618.md) for obsolete types or members; use the custom `WFDEVXXX` diagnostic ID values instead. For more information, see [Suppress warnings](#suppress-warnings).
+
+## Reference
+
+The following table provides an index to the `WFDEVXXX` obsoletions and warnings in .NET 7+.
+
+| Diagnostic ID | Warning or error | Description |
+| - | - |
+| [WFDEV001](wfdev001.md) | Warning | Casting to/from <xref:System.IntPtr> is unsafe, use `WParamInternal`, `LParamInternal`, or `ResultInternal` instead. |
+| [WFDEV002](wfdev001.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> controls. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
+| [WFDEV003](wfdev001.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> items. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
+
+## Suppress warnings
+
+It's recommended that you use an available workaround whenever possible. However, if you cannot change your code, you can suppress warnings through a `#pragma` directive or a `<NoWarn>` project setting. If you must use the obsolete APIs and the `WFDEVXXX` diagnostic does not surface as an error, you can suppress the warning in code or in your project file.
+
+To suppress the warnings in code:
+
+```csharp
+// Disable the warning.
+#pragma warning disable WFDEV001
+
+// Code that uses obsolete API.
+//...
+
+// Re-enable the warning.
+#pragma warning restore WFDEV001
+```
+
+To suppress the warnings in a project file:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   <TargetFramework>net6.0</TargetFramework>
+   <!-- NoWarn below suppresses WFDEV001 project-wide -->
+   <NoWarn>$(NoWarn);WFDEV001</NoWarn>
+   <!-- To suppress multiple warnings, you can use multiple NoWarn elements -->
+   <NoWarn>$(NoWarn);WFDEV002</NoWarn>
+   <NoWarn>$(NoWarn);WFDEV003</NoWarn>
+   <!-- Alternatively, you can suppress multiple warnings by using a semicolon-delimited list -->
+   <NoWarn>$(NoWarn);WFDEV001;WFDEV002;WFDEV003</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+> [!NOTE]
+> Suppressing warnings in this way only disables the obsoletion warnings you specify. It doesn't disable any other warnings, including obsoletion warnings with different diagnostic IDs.
+
+## See also
+
+- [Obsolete .NET features in .NET 5+](/dotnet/fundamentals/syslib-diagnostics/obsoletions-overview)
+<!-- - (add link to breaking change page here...)-->

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
@@ -9,7 +9,7 @@ ms.date: 09/09/2022
 
 Starting in .NET 7, some Windows Forms APIs are marked as obsolete (or otherwise produce a warning) with custom diagnostic IDs of the format `WFDEVXXX`.
 
-If you encounter build warnings or errors due to usage of an obsolete API, follow the specific guidance provided for the diagnostic ID listed in the [Reference](#reference) section. Warnings or errors for these obsoletions *can't* be suppressed using the [standard diagnostic ID (CS0618)](../../csharp/language-reference/compiler-messages/cs0618.md) for obsolete types or members; use the custom `WFDEVXXX` diagnostic ID values instead. For more information, see [Suppress warnings](#suppress-warnings).
+If you encounter build warnings or errors due to usage of an obsolete API, follow the specific guidance provided for the diagnostic ID listed in the [Reference](#reference) section. Warnings or errors for these obsoletions *can't* be suppressed using the [standard diagnostic ID (CS0618)](/dotnet/csharp/language-reference/compiler-messages/cs0618) for obsolete types or members; use the custom `WFDEVXXX` diagnostic ID values instead. For more information, see [Suppress warnings](#suppress-warnings).
 
 ## Reference
 

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev001.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev001.md
@@ -1,0 +1,42 @@
+---
+title: WFDEV001 warning
+description: Learn about the Windows Forms obsoletions that generate compile-time warning WFDEV001.
+ms.date: 09/09/2022
+---
+# WFDEV001: WParam, LParam, and Message.Result are obsolete
+
+To reduce the risk of cast and overflow exceptions associated with <xref:System.IntPtr> on different platforms, the Windows Forms SDK disallows direct use of <xref:System.Windows.Forms.Message.WParam?displayProperty=nameWithType>, <xref:System.Windows.Forms.Message.LParam?displayProperty=nameWithType>, and <xref:System.Windows.Forms.Message.Result?displayProperty=nameWithType>. Projects that use the `DEBUG` build of the Windows Forms SDK and that reference <xref:System.Windows.Forms.Message.WParam>, <xref:System.Windows.Forms.Message.LParam>, or <xref:System.Windows.Forms.Message.Result> will fail to compile.
+
+## Workarounds
+
+Update your code to use the new internal properties, either `WParamInternal`, `LParamInternal`, or `ResultInternal` depending on the situation.
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable WFDEV001
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore WFDEV001
+```
+
+To suppress all the `WFDEV001` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);WFDEV001</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev001.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev001.md
@@ -5,7 +5,7 @@ ms.date: 09/09/2022
 ---
 # WFDEV001: WParam, LParam, and Message.Result are obsolete
 
-To reduce the risk of cast and overflow exceptions associated with <xref:System.IntPtr> on different platforms, the Windows Forms SDK disallows direct use of <xref:System.Windows.Forms.Message.WParam?displayProperty=nameWithType>, <xref:System.Windows.Forms.Message.LParam?displayProperty=nameWithType>, and <xref:System.Windows.Forms.Message.Result?displayProperty=nameWithType>. Projects that use the `DEBUG` build of the Windows Forms SDK and that reference <xref:System.Windows.Forms.Message.WParam>, <xref:System.Windows.Forms.Message.LParam>, or <xref:System.Windows.Forms.Message.Result> will fail to compile.
+To reduce the risk of cast and overflow exceptions associated with <xref:System.IntPtr> on different platforms, the Windows Forms SDK disallows direct use of <xref:System.Windows.Forms.Message.WParam?displayProperty=nameWithType>, <xref:System.Windows.Forms.Message.LParam?displayProperty=nameWithType>, and <xref:System.Windows.Forms.Message.Result?displayProperty=nameWithType>. Projects that use the `DEBUG` build of the Windows Forms SDK and that reference <xref:System.Windows.Forms.Message.WParam>, <xref:System.Windows.Forms.Message.LParam>, or <xref:System.Windows.Forms.Message.Result> will fail to compile due to warning `WFDEV001`.
 
 ## Workarounds
 

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev002.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev002.md
@@ -1,0 +1,43 @@
+---
+title: WFDEV002 warning
+description: Learn about Windows Forms compile-time warning WFDEV002.
+ms.date: 09/09/2022
+---
+# WFDEV002: DomainUpDownAccessibleObject should not be used
+
+Any reference to <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject?displayProperty=fullName> will result in warning `WFDEV002`. This warning states that <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> controls. This type was never intended for public use.
+
+## Workarounds
+
+- Update your code to use <xref:System.Windows.Forms.AccessibleObject> instead of <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject>.
+- If you [suppress the warning](#suppress-a-warning), your code will continue to compile and run in .NET 7.
+
+## Suppress a warning
+
+If you must use the obsolete API, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable WFDEV002
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore WFDEV002
+```
+
+To suppress all the `WFDEV002` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);WFDEV002</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev003.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev003.md
@@ -3,7 +3,7 @@ title: WFDEV003 warning
 description: Learn about Windows Forms compile-time warning WFDEV003.
 ms.date: 09/09/2022
 ---
-# WFDEV003: 
+# WFDEV003: DomainItemAccessibleObject should not be used
 
 Any reference to <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject?displayProperty=fullName> will result in warning `WFDEV003`. This warning states that <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject> is no longer used to provide accessible support for items in <xref:System.Windows.Forms.DomainUpDown> controls. This type was never intended for public use.
 

--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev003.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/wfdev003.md
@@ -1,0 +1,44 @@
+---
+title: WFDEV003 warning
+description: Learn about Windows Forms compile-time warning WFDEV003.
+ms.date: 09/09/2022
+---
+# WFDEV003: 
+
+Any reference to <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject?displayProperty=fullName> will result in warning `WFDEV003`. This warning states that <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject> is no longer used to provide accessible support for items in <xref:System.Windows.Forms.DomainUpDown> controls. This type was never intended for public use.
+
+Previously, objects of this type were served to accessibility tools that navigated the hierarchy of a <xref:System.Windows.Forms.DomainUpDown> control. In .NET 7 and later versions, instances of type <xref:System.Windows.Forms.AccessibleObject> are used to represent items in a <xref:System.Windows.Forms.DomainUpDown> control for accessibility tools.
+
+## Workarounds
+
+Remove invocations of the public constructor for the <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject> type. Use <xref:System.Windows.Forms.AccessibleObject?displayProperty=fullName> instead.
+
+## Suppress a warning
+
+If you must use the obsolete APIs, you can suppress the warning in code or in your project file.
+
+To suppress only a single violation, add preprocessor directives to your source file to disable and then re-enable the warning.
+
+```csharp
+// Disable the warning.
+#pragma warning disable WFDEV003
+
+// Code that uses obsolete API.
+// ...
+
+// Re-enable the warning.
+#pragma warning restore WFDEV003
+```
+
+To suppress all the `WFDEV003` warnings in your project, add a `<NoWarn>` property to your project file.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+   ...
+   <NoWarn>$(NoWarn);WFDEV003</NoWarn>
+  </PropertyGroup>
+</Project>
+```
+
+For more information, see [Suppress warnings](obsoletions-overview.md#suppress-warnings).


### PR DESCRIPTION
Contributes to https://github.com/dotnet/docs/issues/30640.

[Preview link](https://review.docs.microsoft.com/en-us/dotnet/desktop/winforms/wfdev-diagnostics/obsoletions-overview?view=netdesktop-6.0&branch=pr-en-us-1503).