### PR TITLE
fix drop target bug in the WPFdrop target walkthrough

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
@@ -280,6 +280,8 @@ In this section, you enable the panels that host the Circle user controls to act
 
 2. As shown in the following XAML, in each of the <xref:System.Windows.Controls.StackPanel> controls, add handlers for the <xref:System.Windows.UIElement.DragOver> and <xref:System.Windows.UIElement.Drop> events. Name the <xref:System.Windows.UIElement.DragOver> event handler, `panel_DragOver`, and name the <xref:System.Windows.UIElement.Drop> event handler, `panel_Drop`.
 
+   By default, the panels aren't drop targets. Add the <xref:System.Windows.UIElement.AllowDrop%2A> property to both panels and set it to `true`.
+
      [!code-xaml[DragDropWalkthrough#PanelsXAML](~/samples/snippets/csharp/VS_Snippets_Wpf/DragDropWalkthrough/CS/MainWindow.xaml#panelsxaml)]
 
 3. Open MainWindows.xaml.cs or MainWindow.xaml.vb.

--- a/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
@@ -280,7 +280,7 @@ In this section, you enable the panels that host the Circle user controls to act
 
 2. As shown in the following XAML, in each of the <xref:System.Windows.Controls.StackPanel> controls, add handlers for the <xref:System.Windows.UIElement.DragOver> and <xref:System.Windows.UIElement.Drop> events. Name the <xref:System.Windows.UIElement.DragOver> event handler, `panel_DragOver`, and name the <xref:System.Windows.UIElement.Drop> event handler, `panel_Drop`.
 
-   By default, the panels aren't drop targets. To enable them, add the <xref:System.Windows.UIElement.AllowDrop%2A> property to both panels and set it to `true`.
+   By default, the panels aren't drop targets. To enable them, add the <xref:System.Windows.UIElement.AllowDrop%2A> property to both panels and set the value to `true`.
 
      [!code-xaml[DragDropWalkthrough#PanelsXAML](~/samples/snippets/csharp/VS_Snippets_Wpf/DragDropWalkthrough/CS/MainWindow.xaml#panelsxaml)]
 

--- a/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/walkthrough-enabling-drag-and-drop-on-a-user-control.md
@@ -280,7 +280,7 @@ In this section, you enable the panels that host the Circle user controls to act
 
 2. As shown in the following XAML, in each of the <xref:System.Windows.Controls.StackPanel> controls, add handlers for the <xref:System.Windows.UIElement.DragOver> and <xref:System.Windows.UIElement.Drop> events. Name the <xref:System.Windows.UIElement.DragOver> event handler, `panel_DragOver`, and name the <xref:System.Windows.UIElement.Drop> event handler, `panel_Drop`.
 
-   By default, the panels aren't drop targets. Add the <xref:System.Windows.UIElement.AllowDrop%2A> property to both panels and set it to `true`.
+   By default, the panels aren't drop targets. To enable them, add the <xref:System.Windows.UIElement.AllowDrop%2A> property to both panels and set it to `true`.
 
      [!code-xaml[DragDropWalkthrough#PanelsXAML](~/samples/snippets/csharp/VS_Snippets_Wpf/DragDropWalkthrough/CS/MainWindow.xaml#panelsxaml)]
 


### PR DESCRIPTION
## Summary

The `AllowDrop` property was in the XAML but not called out in the steps. It's easily missed.

Fixes #1505
