### PR TITLE
Update virtualmode.cs

### DIFF
--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.DataGridView.VirtualMode/CS/virtualmode.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.DataGridView.VirtualMode/CS/virtualmode.cs
@@ -79,7 +79,7 @@ public class Form1 : Form
         this.dataGridView1.Columns.Add(companyNameColumn);
         this.dataGridView1.Columns.Add(contactNameColumn);
         this.dataGridView1.AutoSizeColumnsMode =
-            DataGridViewAutoSizeColumnsMode.AllCells;
+            DataGridViewAutoSizeColumnsMode.DisplayedCells;
 
         // Add some sample entries to the data store.
         this.customers.Add(new Customer(


### PR DESCRIPTION
Avoid DataGridAutoSizeColumnsMode.AllCells, as that loads the entire grid (which could be millions of lines) regardless of the virtual display size.

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
