### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Thank you for your interest in contributing to the .NET documentation!
 
-We have moved our guidelines into a site-wide contribution guide. To see the guidance, visit the [Microsoft Docs contributor guide](https://docs.microsoft.com/contribute/dotnet/dotnet-contribute).
+We have moved our guidelines into a site-wide contribution guide. To see the guidance, visit the [Microsoft Docs contributor guide](https://learn.microsoft.com/contribute/dotnet/dotnet-contribute).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Markdownlint](https://github.com/dotnet/docs-desktop/workflows/Markdownlint/badge.svg) [![target supported version](https://github.com/dotnet/docs-desktop/actions/workflows/version-sweep.yml/badge.svg)](https://github.com/dotnet/docs-desktop/actions/workflows/version-sweep.yml)
 
-This repository contains the conceptual documentation for .NET desktop technologies, such as Windows Presentation Foundation (WPF) and Windows Forms (WinForms). It's published at the [.NET Desktop Guide documentation site](https://docs.microsoft.com/dotnet/desktop).
+This repository contains the conceptual documentation for .NET desktop technologies, such as Windows Presentation Foundation (WPF) and Windows Forms (WinForms). It's published at the [.NET Desktop Guide documentation site](https://learn.microsoft.com/dotnet/desktop).
 
 ## Issues
 
@@ -12,7 +12,7 @@ We welcome contributions to help us improve and complete the .NET docs. This is 
 
 ## Migrate old examples
 
-If you're interested in helping migrate existing code that targets the .NET Framework (specifically WPF and WinForms) from the [retired Code Gallery](https://docs.microsoft.com/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://docs.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
+If you're interested in helping migrate existing code that targets the .NET Framework (specifically WPF and WinForms) from the [retired Code Gallery](https://learn.microsoft.com/teamblog/msdn-code-gallery-retired) site to .NET Core applications stored in our [samples repository](https://github.com/dotnet/samples) and downloadable from the [Samples Browser](https://learn.microsoft.com/samples/browse), see the [Code Gallery migration](https://github.com/dotnet/docs/projects/88) project. The code gallery samples were moved to the [Microsoft Archive](https://github.com/microsoftarchive?q=msdn-code-gallery) organization.
 
 ## Code of Conduct
 

--- a/dotnet-desktop-guide/framework/wpf/advanced/getting-started-with-ink.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/getting-started-with-ink.md
@@ -17,7 +17,7 @@ Windows Presentation Foundation (WPF) has an ink feature that makes it easy to i
 
 ## Prerequisites
 
-To use the following examples, first install [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019). It also helps to know how to write basic WPF apps. For help getting started with WPF, see [Walkthrough: My first WPF desktop application](../getting-started/walkthrough-my-first-wpf-desktop-application.md).
+To use the following examples, first install [Visual Studio](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019). It also helps to know how to write basic WPF apps. For help getting started with WPF, see [Walkthrough: My first WPF desktop application](../getting-started/walkthrough-my-first-wpf-desktop-application.md).
 
 ## Quick Start
 

--- a/dotnet-desktop-guide/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md
+++ b/dotnet-desktop-guide/framework/wpf/getting-started/walkthrough-my-first-wpf-desktop-application.md
@@ -40,7 +40,7 @@ By the end of the tutorial, you'll have built a standalone Windows application t
 
 ## Prerequisites
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **.NET desktop development** workload installed.
+- [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **.NET desktop development** workload installed.
 
    For more information about installing the latest version of Visual Studio, see [Install Visual Studio](/visualstudio/install/install-visual-studio).
 

--- a/dotnet-desktop-guide/net/winforms/get-started/create-app-visual-studio.md
+++ b/dotnet-desktop-guide/net/winforms/get-started/create-app-visual-studio.md
@@ -27,7 +27,7 @@ In this tutorial, you learn how to:
 
 :::moniker range="netdesktop-5.0"
 
-- [Visual Studio 2019 version 16.8 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms)
+- [Visual Studio 2019 version 16.8 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms)
   - Select the [Visual Studio Desktop workload](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-workloads)
   - Select the [.NET 5 individual component](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-individual-components)
 
@@ -35,7 +35,7 @@ In this tutorial, you learn how to:
 
 :::moniker range="netdesktop-6.0"
 
-- [Visual Studio 2022 version 17.0 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&0utm_content=download+vs2022+desktopguide+winforms)
+- [Visual Studio 2022 version 17.0 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&0utm_content=download+vs2022+desktopguide+winforms)
   - Select the [.NET desktop development workload](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-workloads)
   - Select the [.NET 6 individual component](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-individual-components)
 

--- a/dotnet-desktop-guide/net/winforms/index.yml
+++ b/dotnet-desktop-guide/net/winforms/index.yml
@@ -33,7 +33,7 @@ landingContent:
       - linkListType: download
         links:
           - text: Visual Studio 2022 version 17.0
-            url: https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2022+desktopguide+winforms
+            url: https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2022+desktopguide+winforms
 
   - title: Controls
     linkLists:

--- a/dotnet-desktop-guide/net/winforms/migration/index.md
+++ b/dotnet-desktop-guide/net/winforms/migration/index.md
@@ -21,7 +21,7 @@ For more information, see [Upgrade a WPF App to .NET 5 with the .NET Upgrade Ass
 
 ## Prerequisites
 
-- [Visual Studio 2019 version 16.11](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms) or later.
+- [Visual Studio 2019 version 16.11](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms) or later.
 
   - Select the [Visual Studio Desktop workload](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-workloads).
 

--- a/dotnet-desktop-guide/net/winforms/overview/index.md
+++ b/dotnet-desktop-guide/net/winforms/overview/index.md
@@ -16,9 +16,9 @@ There are two implementations of Windows Forms:
 
 01. The open-source implementation hosted on [GitHub](https://github.com/dotnet/winforms).
 
-    This version runs on .NET 5+ (and .NET Core 3.1). The Windows Forms Visual Designer requires, at a minimum, [Visual Studio 2019 version 16.8](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms).
+    This version runs on .NET 5+ (and .NET Core 3.1). The Windows Forms Visual Designer requires, at a minimum, [Visual Studio 2019 version 16.8](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms).
 
-    The latest version of Windows Forms is for .NET 6 using [Visual Studio 2022 version 17.0](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2022+desktopguide+winforms).
+    The latest version of Windows Forms is for .NET 6 using [Visual Studio 2022 version 17.0](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2022+desktopguide+winforms).
 
 01. The .NET Framework 4 implementation that's supported by Visual Studio 2022, Visual Studio 2019, and Visual Studio 2017.
 

--- a/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md
+++ b/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md
@@ -33,7 +33,7 @@ Here's a preview of the app you'll build while following this tutorial:
 
 :::moniker range="netdesktop-5.0"
 
-- [Visual Studio 2019 version 16.8 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms)
+- [Visual Studio 2019 version 16.8 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+winforms)
   - Select the [Visual Studio Desktop workload](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-workloads)
   - Select the [.NET 5 individual component](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-individual-components)
 
@@ -41,7 +41,7 @@ Here's a preview of the app you'll build while following this tutorial:
 
 :::moniker range="netdesktop-6.0"
 
-- [Visual Studio 2022 version 17.0 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&0utm_content=download+vs2022+desktopguide+winforms)
+- [Visual Studio 2022 version 17.0 or later versions](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&0utm_content=download+vs2022+desktopguide+winforms)
   - Select the [.NET desktop development workload](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-workloads)
   - Select the [.NET 6 individual component](/visualstudio/install/modify-visual-studio?view=vs-2019&preserve-view=true#modify-individual-components)
 

--- a/dotnet-desktop-guide/net/wpf/index.yml
+++ b/dotnet-desktop-guide/net/wpf/index.yml
@@ -34,7 +34,7 @@ landingContent:
       - linkListType: download
         links:
           - text: Visual Studio 2019 version 16.9
-            url: https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+wpf
+            url: https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+wpf
 
   - title: WPF windows
     linkLists:

--- a/dotnet-desktop-guide/net/wpf/overview/index.md
+++ b/dotnet-desktop-guide/net/wpf/overview/index.md
@@ -19,7 +19,7 @@ There are two implementations of WPF:
 
 01. **.NET** version (this guide):
 
-    An open-source implementation of WPF hosted on [GitHub](https://github.com/dotnet/wpf), which runs on .NET 5 or higher (including .NET Core 3.1). The XAML designer requires, at a minimum, [Visual Studio 2019 version 16.8](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+wpf).
+    An open-source implementation of WPF hosted on [GitHub](https://github.com/dotnet/wpf), which runs on .NET 5 or higher (including .NET Core 3.1). The XAML designer requires, at a minimum, [Visual Studio 2019 version 16.8](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=learn.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019+desktopguide+wpf).
 
     Even though .NET is a cross-platform technology, WPF isn't and only runs on Windows.
 

--- a/redirects_generator/readme.md
+++ b/redirects_generator/readme.md
@@ -35,8 +35,8 @@ When you use the version switcher to move from moniker `netdesktop-5.0` to `netf
 
 | Moniker | URL |
 | - | - |
-| `Moniker1` | `https://docs.microsoft.com/dotnet/desktop/winforms/creating-event-handlers-in-windows-forms?view=netframeworkdesktop-4.8` |
-| `Moniker2` | `https://docs.microsoft.com/dotnet/desktop/winforms/creating-event-handlers-in-windows-forms?view=netdesktop-5.0` |
+| `Moniker1` | `https://learn.microsoft.com/dotnet/desktop/winforms/creating-event-handlers-in-windows-forms?view=netframeworkdesktop-4.8` |
+| `Moniker2` | `https://learn.microsoft.com/dotnet/desktop/winforms/creating-event-handlers-in-windows-forms?view=netdesktop-5.0` |
 
 Based on the publishing path and repo paths of the monikers registered with the build system, you can reverse engineer the path to the source file by continually transforming the URL:
 
@@ -116,4 +116,3 @@ The `Redirect` field represents the type of redirect and can be one of the follo
 - `NormalDocId`
 
   This is the same as `Normal` but it adds the `redirect_document_id: true` entry to the redirect.
-


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
