### PR TITLE
Fix diagnostic ID links for WinForms obsoletion reference

### DIFF
--- a/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
+++ b/dotnet-desktop-guide/net/winforms/wfdev-diagnostics/obsoletions-overview.md
@@ -18,8 +18,8 @@ The following table provides an index to the `WFDEVXXX` obsoletions and warnings
 | Diagnostic ID | Warning or error | Description |
 | - | - |
 | [WFDEV001](wfdev001.md) | Warning | Casting to/from <xref:System.IntPtr> is unsafe. Use `WParamInternal`, `LParamInternal`, or `ResultInternal` instead. |
-| [WFDEV002](wfdev001.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> controls. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
-| [WFDEV003](wfdev001.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> items. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
+| [WFDEV002](wfdev002.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> controls. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
+| [WFDEV003](wfdev003.md) | Warning | <xref:System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject?displayProperty=nameWithType> is no longer used to provide accessible support for <xref:System.Windows.Forms.DomainUpDown> items. Use <xref:System.Windows.Forms.AccessibleObject> instead. |
 
 ## Suppress warnings
 


### PR DESCRIPTION
## Summary

Links for different obsoletion diagnostic IDs were pointing to the same page. Now they point to pages corresponding to the obsoletion.

Also, table on [this page](https://github.com/dotnet/docs/blob/main/docs/core/compatibility/windows-forms/7.0/obsolete-apis.md) already has correct links.