### PR TITLE
Fix typo in Bitmap examples

### DIFF
--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImageElementExample_snip/CSharp/ImageSimpleExample.xaml
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImageElementExample_snip/CSharp/ImageSimpleExample.xaml
@@ -16,7 +16,7 @@
          <!-- To save significant application memory, set the DecodePixelWidth or  
           DecodePixelHeight of the BitmapImage value of the image source to the desired 
           height and width of the rendered image. If you don't do this, the application will 
-          cache the image as though it were rendered as its normal size rather then just 
+          cache the image as though it were rendered as its normal size rather than just 
           the size that is displayed. -->
          <!-- Note: In order to preserve aspect ratio, only set either DecodePixelWidth
               or DecodePixelHeight but not both. -->

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImageElementExample_snip/CSharp/ImageSimpleExample.xaml.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImageElementExample_snip/CSharp/ImageSimpleExample.xaml.cs
@@ -33,7 +33,7 @@ namespace ImageElementExample
           // To save significant application memory, set the DecodePixelWidth or
           // DecodePixelHeight of the BitmapImage value of the image source to the desired
           // height or width of the rendered image. If you don't do this, the application will
-          // cache the image as though it were rendered as its normal size rather then just
+          // cache the image as though it were rendered as its normal size rather than just
           // the size that is displayed.
           // Note: In order to preserve aspect ratio, set DecodePixelWidth
           // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/ChainedBitmapSourcesExample.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/ChainedBitmapSourcesExample.cs
@@ -25,7 +25,7 @@ namespace SDKSample
             // To save significant application memory, set the DecodePixelWidth or
             // DecodePixelHeight of the BitmapImage value of the image source to the desired
             // height or width of the rendered image. If you don't do this, the application will
-            // cache the image as though it were rendered as its normal size rather then just
+            // cache the image as though it were rendered as its normal size rather than just
             // the size that is displayed.
             // Note: In order to preserve aspect ratio, set DecodePixelWidth
             // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/CroppedBitmapExample.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/CroppedBitmapExample.cs
@@ -25,7 +25,7 @@ namespace SDKSample
             // To save significant application memory, set the DecodePixelWidth or
             // DecodePixelHeight of the BitmapImage value of the image source to the desired
             // height or width of the rendered image. If you don't do this, the application will
-            // cache the image as though it were rendered as its normal size rather then just
+            // cache the image as though it were rendered as its normal size rather than just
             // the size that is displayed.
             // Note: In order to preserve aspect ratio, set DecodePixelWidth
             // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/FormatConvertedBitmapExample.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/FormatConvertedBitmapExample.cs
@@ -25,7 +25,7 @@ namespace SDKSample
             // To save significant application memory, set the DecodePixelWidth or
             // DecodePixelHeight of the BitmapImage value of the image source to the desired
             // height or width of the rendered image. If you don't do this, the application will
-            // cache the image as though it were rendered as its normal size rather then just
+            // cache the image as though it were rendered as its normal size rather than just
             // the size that is displayed.
             // Note: In order to preserve aspect ratio, set DecodePixelWidth
             // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/FormatConvertedBitmapExample2.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/FormatConvertedBitmapExample2.cs
@@ -25,7 +25,7 @@ namespace SDKSample
             // To save significant application memory, set the DecodePixelWidth or
             // DecodePixelHeight of the BitmapImage value of the image source to the desired
             // height or width of the rendered image. If you don't do this, the application will
-            // cache the image as though it were rendered as its normal size rather then just
+            // cache the image as though it were rendered as its normal size rather than just
             // the size that is displayed.
             // Note: In order to preserve aspect ratio, set DecodePixelWidth
             // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/PixelFormatsExample.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/PixelFormatsExample.cs
@@ -26,7 +26,7 @@ namespace SDKSample
             // To save significant application memory, set the DecodePixelWidth or
             // DecodePixelHeight of the BitmapImage value of the image source to the desired
             // height or width of the rendered image. If you don't do this, the application will
-            // cache the image as though it were rendered as its normal size rather then just
+            // cache the image as though it were rendered as its normal size rather than just
             // the size that is displayed.
             // Note: In order to preserve aspect ratio, set DecodePixelWidth
             // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/TransformedBitmapExample.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/CSharp/TransformedBitmapExample.cs
@@ -25,7 +25,7 @@ namespace SDKSample
             // To save significant application memory, set the DecodePixelWidth or
             // DecodePixelHeight of the BitmapImage value of the image source to the desired
             // height or width of the rendered image. If you don't do this, the application will
-            // cache the image as though it were rendered as its normal size rather then just
+            // cache the image as though it were rendered as its normal size rather than just
             // the size that is displayed.
             // Note: In order to preserve aspect ratio, set DecodePixelWidth
             // or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImageElementExample_snip/VB/ImageSimpleExample.xaml
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImageElementExample_snip/VB/ImageSimpleExample.xaml
@@ -15,7 +15,7 @@
          <!-- To save significant application memory, set the DecodePixelWidth or  
           DecodePixelHeight of the BitmapImage value of the image source to the desired 
           height and width of the rendered image. If you don't do this, the application will 
-          cache the image as though it were rendered as its normal size rather then just 
+          cache the image as though it were rendered as its normal size rather than just 
           the size that is displayed. -->
          <!-- Note: In order to preserve aspect ratio, only set either DecodePixelWidth
               or DecodePixelHeight but not both. -->

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImageElementExample_snip/VB/ImageSimpleExample.xaml.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImageElementExample_snip/VB/ImageSimpleExample.xaml.vb
@@ -43,7 +43,7 @@ Namespace ImageElementExample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/ChainedBitmapSourcesExample.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/ChainedBitmapSourcesExample.vb
@@ -23,7 +23,7 @@ Namespace SDKSample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/CroppedBitmapExample.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/CroppedBitmapExample.vb
@@ -23,7 +23,7 @@ Namespace SDKSample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/FormatConvertedBitmapExample.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/FormatConvertedBitmapExample.vb
@@ -23,7 +23,7 @@ Namespace SDKSample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/FormatConvertedBitmapExample2.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/FormatConvertedBitmapExample2.vb
@@ -24,7 +24,7 @@ Namespace SDKSample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/PixelFormatsExample.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/PixelFormatsExample.vb
@@ -24,7 +24,7 @@ Namespace SDKSample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/TransformedBitmapExample.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/ImagingSnippetGallery_procedural_snip/VB/TransformedBitmapExample.vb
@@ -23,7 +23,7 @@ Namespace SDKSample
             ' To save significant application memory, set the DecodePixelWidth or  
             ' DecodePixelHeight of the BitmapImage value of the image source to the desired 
             ' height or width of the rendered image. If you don't do this, the application will 
-            ' cache the image as though it were rendered as its normal size rather then just 
+            ' cache the image as though it were rendered as its normal size rather than just 
             ' the size that is displayed.
             ' Note: In order to preserve aspect ratio, set DecodePixelWidth
             ' or DecodePixelHeight but not both.


### PR DESCRIPTION
## Summary

Fixed a typo in the Bitmap examples. My editor also added final newlines to some of the documents because that is what your `.editorconfig` tells it to do :)
