### PR TITLE
Add bottom margin to match with preview image

### DIFF
--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ExpenseIt/CSharp/ExpenseIt4/ExpenseItHome.xaml
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/ExpenseIt/CSharp/ExpenseIt4/ExpenseItHome.xaml
@@ -34,7 +34,7 @@
         </ListBox>
 
         <!-- View report button -->
-        <Button Grid.Column="0" Grid.Row="2" Margin="0,10,0,0" Width="125" Height="25" HorizontalAlignment="Right">View</Button>
+        <Button Grid.Column="0" Grid.Row="2" Margin="0,10,0,10" Width="125" Height="25" HorizontalAlignment="Right">View</Button>
         <!--</Snippet10>-->
 
     </Grid>


### PR DESCRIPTION
## Summary

The button (visible in the preview image below in the documentation) has a clearly visible bottom margin. So this commit adds a margin of 10 to match the snippet with the preview image.
