### PR TITLE
Fix Typo

### DIFF
--- a/dotnet-desktop-guide/net/wpf/data/binding-sources-overview.md
+++ b/dotnet-desktop-guide/net/wpf/data/binding-sources-overview.md
@@ -26,7 +26,7 @@ Windows Presentation Foundation (WPF) data binding supports the following bindin
 
 - **Dynamic objects**
 
-  You can bind to available properties and indexers of an object that implements the <xref:System.Dynamic.IDynamicMetaObjectProvider> interface. If you can access the member in code, you can bind to it. For example, if a dynamic object enables you to access a member in code via `someObjet.AProperty`, you can bind to it by setting the binding path to `AProperty`.
+  You can bind to available properties and indexers of an object that implements the <xref:System.Dynamic.IDynamicMetaObjectProvider> interface. If you can access the member in code, you can bind to it. For example, if a dynamic object enables you to access a member in code via `SomeObject.AProperty`, you can bind to it by setting the binding path to `AProperty`.
 
 - **ADO.NET objects**
 


### PR DESCRIPTION
## Summary

-  Fixes typo, by including all letters and using uppercase.

Fixes #1603


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/data/binding-sources-overview.md](https://github.com/dotnet/docs-desktop/blob/998c1902624e195da60031f18a7c5adb196c4ff2/dotnet-desktop-guide/net/wpf/data/binding-sources-overview.md) | [Binding sources overview (WPF .NET)](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/data/binding-sources-overview?branch=pr-en-us-1618&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->