### PR TITLE
Fix typo from foreground to background

### DIFF
--- a/dotnet-desktop-guide/net/wpf/controls/how-to-create-apply-template.md
+++ b/dotnet-desktop-guide/net/wpf/controls/how-to-create-apply-template.md
@@ -148,7 +148,7 @@ Run the project. Notice that when you move the mouse over the button, the color 
 
 ## Use a VisualState
 
-Visual states are defined and triggered by a control. For example, when the mouse is moved on top of the control, the `CommonStates.MouseOver` state is triggered. You can animate property changes based on the current state of the control. In the previous section, a **\<PropertyTrigger>** was used to change the foreground of the button to `AliceBlue` when the `IsMouseOver` property was `true`. Instead, create a visual state that animates the change of this color, providing a smooth transition. For more information about *VisualStates*, see [Styles and templates in WPF](styles-templates-overview.md#visual-states).
+Visual states are defined and triggered by a control. For example, when the mouse is moved on top of the control, the `CommonStates.MouseOver` state is triggered. You can animate property changes based on the current state of the control. In the previous section, a **\<PropertyTrigger>** was used to change the background of the button to `AliceBlue` when the `IsMouseOver` property was `true`. Instead, create a visual state that animates the change of this color, providing a smooth transition. For more information about *VisualStates*, see [Styles and templates in WPF](styles-templates-overview.md#visual-states).
 
 To convert the **\<PropertyTrigger>** to an animated visual state, First, remove the **\<ControlTemplate.Triggers>** element from your template.
 


### PR DESCRIPTION
Change "foreground" in line 151 to "background"

## Summary

@taalha looks like your branch that fixed this opened a pull request between your own repository. I've opened this one from your repository to this repository. Thanks!

Fixes #1376

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/controls/how-to-create-apply-template.md](https://github.com/dotnet/docs-desktop/blob/9a3edf6bb48dd8140cc7ae9bd33c0e9612c9f682/dotnet-desktop-guide/net/wpf/controls/how-to-create-apply-template.md) | [How to create a template for a control (WPF.NET)](https://review.learn.microsoft.com/en-us/dotnet/dotnet-desktop-guide/net/wpf/controls/how-to-create-apply-template?branch=pr-en-us-1627) |


<!-- PREVIEW-TABLE-END -->