### PR TITLE
Update how-to-display-web-style-links-with-the-windows-forms-richtext…

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-display-web-style-links-with-the-windows-forms-richtextbox-control.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-display-web-style-links-with-the-windows-forms-richtextbox-control.md
@@ -18,7 +18,7 @@ The Windows Forms <xref:System.Windows.Forms.RichTextBox> control can display We
 
 ### To link to a Web page with the RichTextBox control
 
-1. Set the <xref:System.Windows.Forms.RichTextBox.Text%2A> property to a string that includes a valid URL (for example, "https://www.microsoft.com/").
+1. Set the <xref:System.Windows.Forms.RichTextBox.Text%2A> property to a string that includes a valid URL (for example, `https://www.microsoft.com/`).
 
 2. Make sure the <xref:System.Windows.Forms.RichTextBox.DetectUrls%2A> property is set to `true` (the default).
 


### PR DESCRIPTION
Fix new linter error


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/controls/how-to-display-web-style-links-with-the-windows-forms-richtextbox-control.md](https://github.com/dotnet/docs-desktop/blob/a744f83d2b1e9d533ab4565bf0b025096d612f44/dotnet-desktop-guide/framework/winforms/controls/how-to-display-web-style-links-with-the-windows-forms-richtextbox-control.md) | [How to: Display Web-Style Links with the Windows Forms RichTextBox Control](https://review.learn.microsoft.com/en-us/dotnet/dotnet-desktop-guide/framework/winforms/controls/how-to-display-web-style-links-with-the-windows-forms-richtextbox-control?branch=pr-en-us-1628) |

<!-- PREVIEW-TABLE-END -->