### PR TITLE
Fix XML for DPI

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/high-dpi-support-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/high-dpi-support-in-windows-forms.md
@@ -77,7 +77,7 @@ In addition, to configure high DPI support in your Windows Forms application, yo
 Setting the `DpiAwareness` value to `PerMonitorV2` enables all high DPI awareness features supported by .NET Framework versions starting with the .NET Framework 4.7. Typically, this is adequate for most Windows Forms applications. However, you may want to opt out of one or more individual features. The most important reason for doing this is that your existing application code already handles that feature.  For example, if your application handles auto scaling, you might want to disable the auto-resizing feature as follows:
 
 ```xml
-<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+<configuration>
   <!-- ... other xml settings ... -->
 
   <System.Windows.Forms.ApplicationConfigurationSection>
@@ -85,7 +85,7 @@ Setting the `DpiAwareness` value to `PerMonitorV2` enables all high DPI awarenes
     <add key="EnableWindowsFormsHighDpiAutoResizing" value="false" />
   </System.Windows.Forms.ApplicationConfigurationSection>
 
-</compatibility>
+</configuration>
 ```
 
 For a list of individual keys and their values, see [Windows Forms Add Configuration Element](/dotnet/framework/configure-apps/file-schema/winforms/windows-forms-add-configuration-element).


### PR DESCRIPTION
XML was using a manifest node for an app.config node.

Fixes #1559


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/high-dpi-support-in-windows-forms.md](https://github.com/dotnet/docs-desktop/blob/6cfbf0fe2a9e91389a39e97b2582ebe6c5bf313d/dotnet-desktop-guide/framework/winforms/high-dpi-support-in-windows-forms.md) | [High DPI support in Windows Forms](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/high-dpi-support-in-windows-forms?branch=pr-en-us-1648&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->