### PR TITLE
Fix link in the porting wpf article

### DIFF
--- a/dotnet-desktop-guide/net/wpf/migration/index.md
+++ b/dotnet-desktop-guide/net/wpf/migration/index.md
@@ -83,7 +83,7 @@ If your application encountered any errors, you can find them in the **Error Lis
 
 ## Post-upgrade steps
 
-If your project is being upgraded from .NET Framework to .NET, review the information in the [Modernize after upgrading to .NET from .NET Framework](/core/porting/modernize) article.
+If your project is being upgraded from .NET Framework to .NET, review the information in the [Modernize after upgrading to .NET from .NET Framework](/dotnet/core/porting/modernize) article.
 
 After upgrading, you'll want to:
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/migration/index.md](https://github.com/dotnet/docs-desktop/blob/8549c79fd6bdc078a3866c3824ffbae996be0bbc/dotnet-desktop-guide/net/wpf/migration/index.md) | [How to upgrade a WPF desktop app to .NET 7](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/migration/index?branch=pr-en-us-1650&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->