### PR TITLE
Update clipboard article

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/advanced/how-to-add-data-to-the-clipboard.md
+++ b/dotnet-desktop-guide/framework/winforms/advanced/how-to-add-data-to-the-clipboard.md
@@ -20,7 +20,7 @@ A Clipboard format is a string that identifies the format so that an application
 
 To add data to the Clipboard in one or multiple formats, use the <xref:System.Windows.Forms.Clipboard.SetDataObject%2A> method. You can pass any object to this method, but to add data in multiple formats, you must first add the data to a separate object designed to work with multiple formats. Typically, you will add your data to a <xref:System.Windows.Forms.DataObject>, but you can use any type that implements the <xref:System.Windows.Forms.IDataObject> interface.
 
-In .NET Framework 2.0, you can add data directly to the Clipboard by using new methods designed to make basic Clipboard tasks easier. Use these methods when you work with data in a single, common format such as text.
+To add data to the Clipboard in a single, common format, you can use specific method for that format, such as <xref:System.Windows.Forms.Clipboard.SetText%2A> for text.
 
 > [!NOTE]
 > All Windows-based applications share the Clipboard. Therefore, the contents are subject to change when you switch to another application.
@@ -31,14 +31,14 @@ In .NET Framework 2.0, you can add data directly to the Clipboard by using new m
 
 ### To add data to the Clipboard in a single, common format
 
-1. Use the <xref:System.Windows.Forms.Clipboard.SetAudio%2A>, <xref:System.Windows.Forms.Clipboard.SetFileDropList%2A>, <xref:System.Windows.Forms.Clipboard.SetImage%2A>, or <xref:System.Windows.Forms.Clipboard.SetText%2A> method. These methods are available only in .NET Framework 2.0.
+1. Use the <xref:System.Windows.Forms.Clipboard.SetAudio%2A>, <xref:System.Windows.Forms.Clipboard.SetFileDropList%2A>, <xref:System.Windows.Forms.Clipboard.SetImage%2A>, or <xref:System.Windows.Forms.Clipboard.SetText%2A> method.
 
     [!code-csharp[System.Windows.Forms.Clipboard#2](~/samples/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.Clipboard/CS/form1.cs#2)]
     [!code-vb[System.Windows.Forms.Clipboard#2](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.Clipboard/vb/form1.vb#2)]
 
 ### To add data to the Clipboard in a custom format
 
-1. Use the <xref:System.Windows.Forms.Clipboard.SetData%2A> method with a custom format name. This method is available only in .NET Framework 2.0.
+1. Use the <xref:System.Windows.Forms.Clipboard.SetData%2A> method with a custom format name.
 
     You can also use predefined format names with the <xref:System.Windows.Forms.Clipboard.SetData%2A> method. For more information, see <xref:System.Windows.Forms.DataFormats>.
 
@@ -49,7 +49,7 @@ In .NET Framework 2.0, you can add data directly to the Clipboard by using new m
 
 ### To add data to the Clipboard in multiple formats
 
-1. Use the <xref:System.Windows.Forms.Clipboard.SetDataObject%2A?displayProperty=nameWithType> method and pass in a <xref:System.Windows.Forms.DataObject> that contains your data. You must use this method to add data to the Clipboard on versions earlier than .NET Framework 2.0.
+1. Use the <xref:System.Windows.Forms.Clipboard.SetDataObject%2A?displayProperty=nameWithType> method and pass in a <xref:System.Windows.Forms.DataObject> that contains your data.
 
     [!code-csharp[System.Windows.Forms.Clipboard#4](~/samples/snippets/csharp/VS_Snippets_Winforms/System.Windows.Forms.Clipboard/CS/form1.cs#4)]
     [!code-vb[System.Windows.Forms.Clipboard#4](~/samples/snippets/visualbasic/VS_Snippets_Winforms/System.Windows.Forms.Clipboard/vb/form1.vb#4)]


### PR DESCRIPTION
Remove stale mentions of .NET Framework 2.0. These methods are available in all supported versions, so no need to mention exact version.
