### PR TITLE
Update WPF tutorial to show the grid xaml

### DIFF
--- a/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md
+++ b/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md
@@ -211,7 +211,7 @@ Before we add the new rows and columns, add a new attribute to the `<Grid>` elem
 
 Next, define two rows and two columns, dividing the grid into four cells:
 
-:::code language="xaml" source="snippets/create-app-visual-studio/csharp/LayoutStep2.xaml" highlight="9-21":::
+:::code language="xaml" source="snippets/create-app-visual-studio/csharp/LayoutStep2.xaml" range="9-21":::
 
 Select the grid in either the XAML code editor or XAML designer, you'll see that the XAML designer shows each row and column:
 


### PR DESCRIPTION
## Summary

Change the code snippet to just show the grid and remove confusion related to the class.

Fixes #1665


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md](https://github.com/dotnet/docs-desktop/blob/812eb406de92e733a992f6cfdd9321e8964eafc5/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md) | [Tutorial: Create a new WPF app with .NET](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/get-started/create-app-visual-studio?branch=pr-en-us-1671&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->