### PR TITLE
Framework winforms article is missing the New menu strip step

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
@@ -24,7 +24,7 @@ Use the multiple-document interface (MDI) to create applications that can open s
   
 3. Add two top-level menu items to the <xref:System.Windows.Forms.MenuStrip> and set their <xref:System.Windows.Forms.Control.Text%2A> properties to `&File` and `&Window`.  
   
-4. Add two submenu items to the `&File` menu item and set the <xref:System.Windows.Forms.ToolStripItem.Text%2A> property to `&Open` and `&New`.  
+4. Add two submenu items to the `&File` menu item and set their <xref:System.Windows.Forms.ToolStripItem.Text%2A> properties to `&Open` and `&New`.  
   
 5. Set the <xref:System.Windows.Forms.MenuStrip.MdiWindowListItem%2A> property of the <xref:System.Windows.Forms.MenuStrip> to the `&Window`<xref:System.Windows.Forms.ToolStripMenuItem>.  
   

--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
@@ -24,7 +24,7 @@ Use the multiple-document interface (MDI) to create applications that can open s
   
 3. Add two top-level menu items to the <xref:System.Windows.Forms.MenuStrip> and set their <xref:System.Windows.Forms.Control.Text%2A> properties to `&File` and `&Window`.  
   
-4. Add a submenu item to the `&File` menu item and set its <xref:System.Windows.Forms.ToolStripItem.Text%2A> property to `&Open`.  
+4. Add two submenu items to the `&File` menu item and set the <xref:System.Windows.Forms.ToolStripItem.Text%2A> property to `&Open` and `&New`.  
   
 5. Set the <xref:System.Windows.Forms.MenuStrip.MdiWindowListItem%2A> property of the <xref:System.Windows.Forms.MenuStrip> to the `&Window`<xref:System.Windows.Forms.ToolStripMenuItem>.  
   


### PR DESCRIPTION
## Summary

Add the `&New` menu item step.

Fixes #1663


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md](https://github.com/dotnet/docs-desktop/blob/c0850222d41e8036501b349d4ff314bc79fb460d/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md) | [How to: Create an MDI Window List with MenuStrip (Windows Forms)](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms?branch=pr-en-us-1672&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->