### PR TITLE
Remove useless step in MDI article

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md
@@ -57,17 +57,6 @@ Use the multiple-document interface (MDI) to create applications that can open s
     }  
     ```  
   
-9. Place code like the following in the `&New`<xref:System.Windows.Forms.ToolStripMenuItem> to register the event handler.  
-  
-    ```vb  
-    Private Sub newToolStripMenuItem_Click(sender As Object, e As _  
-    EventArgs) Handles newToolStripMenuItem.Click  
-    ```  
-  
-    ```csharp  
-    this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);  
-    ```  
-  
 ## Compiling the Code  
 
  This example requires:  


### PR DESCRIPTION
## Summary

Previous step already instructs the reader to add the event handler.

Fixes #1673


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md](https://github.com/dotnet/docs-desktop/blob/8db8084286d84c1460ffcd96e98987855b8a72bf/dotnet-desktop-guide/framework/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms.md) | [How to: Create an MDI Window List with MenuStrip (Windows Forms)](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/how-to-create-an-mdi-window-list-with-menustrip-windows-forms?branch=pr-en-us-1674&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->