### PR TITLE
Fix redirect to proper article

### DIFF
--- a/.openpublishing.redirection.winforms.json
+++ b/.openpublishing.redirection.winforms.json
@@ -447,6 +447,30 @@
         {
             "source_path": "dotnet-desktop-guide/net/winforms/controls/how-to-apply-attributes-in-windows-forms-controls.md",
             "redirect_url": "/dotnet/desktop/winforms/controls-design/designer-overview?view=netdesktop-7.0"
+        },
+        {
+            "source_path": "dotnet-desktop-guide/net/winforms/controls/how-to-inherit-from-the-usercontrol-class.md",
+            "redirect_url": "/dotnet/desktop/winforms/controls-design/how-to-create-usercontrol?view=netdesktop-7.0"
+        },
+        {
+            "source_path": "dotnet-desktop-guide/net/winforms/controls/constituent-controls.md",
+            "redirect_url": "/dotnet/desktop/winforms/controls-design/usercontrol-overview?view=netdesktop-7.0"
+        },
+        {
+            "source_path": "dotnet-desktop-guide/net/winforms/controls/developing-windows-forms-controls-at-design-time.md",
+            "redirect_url": "/dotnet/desktop/winforms/controls-design/usercontrol-overview?view=netdesktop-7.0"
+        },
+        {
+            "source_path": "dotnet-desktop-guide/framework/winforms/controls-design/usercontrol-overview.md",
+            "redirect_url": "/dotnet/desktop/winforms/controls/developing-windows-forms-controls-at-design-time?view=netframeworkdesktop-4.8"
+        },
+        {
+            "source_path": "dotnet-desktop-guide/net/winforms/controls/how-to-give-your-control-a-transparent-background.md",
+            "redirect_url": "/dotnet/desktop/winforms/controls-design/how-to-set-transparent-background?view=netdesktop-7.0"
+        },
+        {
+            "source_path": "dotnet-desktop-guide/framework/winforms/controls-design/how-to-set-transparent-background.md",
+            "redirect_url": "/dotnet/desktop/winforms/controls/how-to-give-your-control-a-transparent-background?view=netframeworkdesktop-4.8"
         }
     ]
 }

--- a/.openpublishing.redirection.winforms.json
+++ b/.openpublishing.redirection.winforms.json
@@ -429,10 +429,6 @@
             "redirect_url": "/dotnet/desktop/winforms/controls/how-to-author-composite-controls?view=netframeworkdesktop-4.8"
         },
         {
-            "source_path": "dotnet-desktop-guide/net/winforms/controls/how-to-inherit-from-the-usercontrol-class.md",
-            "redirect_url": "/dotnet/desktop/winforms/controls-design/usercontrol-overview?view=netdesktop-7.0"
-        },
-        {
             "source_path": "dotnet-desktop-guide/net/winforms/controls/how-to-inherit-from-existing-windows-forms-controls.md",
             "redirect_url": "/dotnet/desktop/winforms/controls-design/extend-existing?view=netdesktop-7.0"
         },

--- a/redirects_generator/definitions.winforms.json
+++ b/redirects_generator/definitions.winforms.json
@@ -140,7 +140,7 @@
         {
             "Redirect": "OneWay",
             "SourceUrl": "/dotnet/desktop/winforms/controls/how-to-inherit-from-the-usercontrol-class?view=netframeworkdesktop-4.8",
-            "TargetUrl": "/dotnet/desktop/winforms/controls-design/usercontrol-overview?view=netdesktop-7.0"
+            "TargetUrl": "/dotnet/desktop/winforms/controls-design/how-to-create-usercontrol?view=netdesktop-7.0"
         },
         {
             "Redirect": "TwoWay",
@@ -156,6 +156,21 @@
             "Redirect": "OneWay",
             "SourceUrl": "/dotnet/desktop/winforms/controls/how-to-apply-attributes-in-windows-forms-controls?view=netframeworkdesktop-4.8",
             "TargetUrl": "/dotnet/desktop/winforms/controls-design/designer-overview?view=netdesktop-7.0"
+        },
+        {
+            "Redirect": "OneWay",
+            "SourceUrl": "/dotnet/desktop/winforms/controls/constituent-controls?view=netframeworkdesktop-4.8",
+            "TargetUrl": "/dotnet/desktop/winforms/controls-design/usercontrol-overview?view=netdesktop-7.0"
+        },
+        {
+            "Redirect": "TwoWay",
+            "SourceUrl": "/dotnet/desktop/winforms/controls/developing-windows-forms-controls-at-design-time?view=netframeworkdesktop-4.8",
+            "TargetUrl": "/dotnet/desktop/winforms/controls-design/usercontrol-overview?view=netdesktop-7.0"
+        },
+        {
+            "Redirect": "TwoWay",
+            "SourceUrl": "/dotnet/desktop/winforms/controls/how-to-give-your-control-a-transparent-background?view=netframeworkdesktop-4.8",
+            "TargetUrl": "/dotnet/desktop/winforms/controls-design/how-to-set-transparent-background?view=netdesktop-7.0"
         },
 
         // Custom painting and drawing


### PR DESCRIPTION
## Summary

- The tutorial article is really the how to article.
- The transparent how to is mostly useless now that the theme doesn't seem to support transparent on many controls. Article will be ported if there is a real use for it.

Fixes #1670