### PR TITLE
Remove obsolete warning

### DIFF
--- a/dotnet-desktop-guide/net/winforms/migration/index.md
+++ b/dotnet-desktop-guide/net/winforms/migration/index.md
@@ -29,9 +29,6 @@ You should also review the information in the [Porting from .NET Framework to .N
 
 This article was written in the context of upgrading the **Windows Forms Matching Game Sample** project, which you can download from the [.NET Samples GitHub repository][winforms-sample].
 
-> [!IMPORTANT]
-> Due to a bug in Windows Forms for .NET 7, the sample project crashes on startup after upgrading. This is fixed in upcoming .NET Desktop Runtime 7.0.6 release. The latest .NET 8 preview contains the same fix.
-
 ## Initiate the upgrade
 
 If you're upgrading multiple projects, start with projects that have no dependencies. In the Matching Game sample, the **MatchingGame** project depends on the **MatchingGame.Logic** library, so **MatchingGame.Logic** should be upgraded first.


### PR DESCRIPTION
Warning about crash on startup is no longer needed, fixed in current .NET release

## Summary

Removed obsolete warning. I ran through the tutorial and verified that the upgraded application runs without crashing and works as expected.

Fixes #1682 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/winforms/migration/index.md](https://github.com/dotnet/docs-desktop/blob/997786c5d03281d59ecd2dc1f99fe6a772b79c2c/dotnet-desktop-guide/net/winforms/migration/index.md) | [How to upgrade a Windows Forms desktop app to .NET 7](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/migration/index?branch=pr-en-us-1683&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->