### PR TITLE
Update Framework debug article with info and links to the out-of-proc designer for .NET

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time.md
@@ -24,7 +24,11 @@ When you create a custom control, you will often find it necessary to debug its 
 You can debug your custom controls using Visual Studio, just as you would debug any other .NET Framework classes. The difference is that you will debug a separate instance of Visual Studio that is running your custom control's code.
 
 > [!IMPORTANT]
-> This article is primarily intended for the classic In-Process Designer for Windows Forms with .NET Framework. The procedures may not be directly applicable or fully compatible with projects that target .NET. Further, Visual Studio 2022 runs on .NET Framework 4.7.2 in a 64-bit environment, which can cause compatibility issues with Out-Of-Process Designers if you target a 32-bit architecture with your .NET applications. For more information about the Out-Of-Process Designer, see [The designer changes since .NET Framework](../../../net/winforms/controls-design/designer-differences-framework.md).
+> This article is primarily intended for the classic In-Process Designer for Windows Forms with .NET Framework. The procedures may not be directly applicable or fully compatible with projects that target .NET (not .NET Framework).
+>
+> For .NET Framework projects, only projects that can compile with the platform target settings _Any_ or _x64_ are fully supported in the Designer. Projects that use ActiveX, COM, or other 32-bit components, may have compatibility issues. The Out-Of_Process Framework Designer, currently in preview, addresses many of those compatibility issues. However, design-time functionality may not work as well as the 64-bit In-Process Designer. To enable the Out-Of-Process Framework Designer, navigate to the **Tools** > **Options** > **Environment** > **Preview Features**.
+>
+> For more information about the Out-Of-Process Designer, see [The designer changes since .NET Framework](../../../net/winforms/controls-design/designer-differences-framework.md).
 
 ## Create the project
 

--- a/dotnet-desktop-guide/framework/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time.md
@@ -23,6 +23,9 @@ When you create a custom control, you will often find it necessary to debug its 
 
 You can debug your custom controls using Visual Studio, just as you would debug any other .NET Framework classes. The difference is that you will debug a separate instance of Visual Studio that is running your custom control's code.
 
+> [!IMPORTANT]
+> This article is primarily intended for the classic In-Process Designer for Windows Forms with .NET Framework. The procedures may not be directly applicable or fully compatible with projects that target .NET. Further, Visual Studio 2022 runs on .NET Framework 4.7.2 in a 64-bit environment, which can cause compatibility issues with Out-Of-Process Designers if you target a 32-bit architecture with your .NET applications. For more information about the Out-Of-Process Designer, see [The designer changes since .NET Framework](../../../net/winforms/controls-design/designer-differences-framework.md).
+
 ## Create the project
 
 The first step is to create the application project. You will use this project to build the application that hosts the custom control.
@@ -126,7 +129,7 @@ Now you are ready to debug your custom control as it runs in design mode. When y
 3. In the new instance of Visual Studio, open the "DebuggingExample" solution. You can easily find the solution by selecting **Recent Projects** from the **File** menu. The "DebuggingExample.sln" solution file will be listed as the most recently used file.
 
    > [!IMPORTANT]
-   > If you're debugging a .NET 5 (.NET Core 3.1) or later Windows Forms project, use this instance of Visual Studio to attach a debugger to the the *DesignToolsServer.exe* process. Select the **Debug** > **Attach to process** menu item. Find *DesignToolsServer.exe* in the list of processes and press **Attach**.
+   > If you're debugging a .NET 6 or later Windows Forms project, don't load the project, instead, use this instance of Visual Studio to attach a debugger to the the *DesignToolsServer.exe* process. Select the **Debug** > **Attach to process** menu item. Find *DesignToolsServer.exe* in the list of processes and press **Attach**. For more information, see [The designer changes since .NET Framework](../../../net/winforms/controls-design/designer-differences-framework.md).
 
 4. Open Form1 in the **Forms Designer** and select the **DebugControl** control.
 


### PR DESCRIPTION
## Summary

- Clarified info about choosing the out-of-proc designer midway through the article.
- Added an intro warning about the out-of-proc designer.

Fixes #1499

@KlausLoeffelmann 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time.md](https://github.com/dotnet/docs-desktop/blob/0bb97ea91c95e6d44af3bf6aa0a93cbec4856e6f/dotnet-desktop-guide/framework/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time.md) | [Walkthrough: Debug Custom Windows Forms Controls at Design Time](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/walkthrough-debugging-custom-windows-forms-controls-at-design-time?branch=pr-en-us-1693&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->