### PR TITLE
Fix bugs in the threading article

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/snippets/threading-model/csharp/App.xaml
+++ b/dotnet-desktop-guide/framework/wpf/advanced/snippets/threading-model/csharp/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="SDKSamples.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="NestedPumpScreenShot.xaml">
+             StartupUri="Weather.xaml">
     <Application.Resources>
 
         <!-- <clock_resources> -->

--- a/dotnet-desktop-guide/framework/wpf/advanced/snippets/threading-model/csharp/Weather.xaml.cs
+++ b/dotnet-desktop-guide/framework/wpf/advanced/snippets/threading-model/csharp/Weather.xaml.cs
@@ -22,7 +22,7 @@ namespace SDKSamples
             ((Storyboard)Resources["HideWeatherImageStoryboard"]).Begin(this);
 
             // Asynchronously fetch the weather forecast on a different thread and pause this code.
-            string weather = await FetchWeatherFromServerAsync();
+            string weather = await Task.Run(FetchWeatherFromServerAsync);
 
             // After async data returns, process it...
             // Set the weather image

--- a/dotnet-desktop-guide/framework/wpf/advanced/snippets/threading-model/vb/Weather.xaml.vb
+++ b/dotnet-desktop-guide/framework/wpf/advanced/snippets/threading-model/vb/Weather.xaml.vb
@@ -13,7 +13,7 @@ Public Class Weather
         DirectCast(Resources("HideWeatherImageStoryboard"), Storyboard).Begin(Me)
 
         ' Asynchronously fetch the weather forecast on a different thread and pause this code.
-        Dim Weather As String = Await FetchWeatherFromServerAsync()
+        Dim Weather As String = Await Task.Run(AddressOf FetchWeatherFromServerAsync)
 
         ' After async data returns, process it...
         ' Set the weather image

--- a/dotnet-desktop-guide/framework/wpf/advanced/threading-model.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/threading-model.md
@@ -163,7 +163,7 @@ There's an easier way to run the code on a new thread while synchronizing the re
 
 ### Task.Run example
 
-In this example, we mimic a remote procedure call that retrieves a weather forecast. When the button is clicked, the UI is updated normally to indicate that the data fetch is in progress, while a task is started to mimic fetching the weather forecast. When the task is started, the button event handler code is suspended until the task finishes. After the task finishes, the event handler code continues to run. The code is suspended and it isn't blocking the rest of the UI thread. The synchronization context of WPF handles suspending the code, which allows WPF to continue to run.
+In this example, we mimic a remote procedure call that retrieves a weather forecast. When the button is clicked, the UI is updated to indicate that the data fetch is in progress, while a task is started to mimic fetching the weather forecast. When the task is started, the button event handler code is suspended until the task finishes. After the task finishes, the event handler code continues to run. The code is suspended, and it doesn't block the rest of the UI thread. The synchronization context of WPF handles suspending the code, which allows WPF to continue to run.
 
 :::image type="complex" source="./media/threading-model/threading-weather-ui.png" alt-text="A diagram that demonstrates the workflow of the example app.":::
 


### PR DESCRIPTION
## Summary

- Renamed `Handle a blocking operation with a background thread` to `Handle a blocking operation with Task.Run`.
- Moved `Handle a blocking operation with Task.Run` to be after `Multiple windows, multiple threads`, which helps talking about the benefits of using `Task.Run` over the threading dispatcher.
- Fixed code examples to use `Task.Run` to actually run the code on a new thread.

Fixes #1720

@IEvangelist since you reviewed this last time 😁 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/advanced/threading-model.md](https://github.com/dotnet/docs-desktop/blob/57af8e1a6df8222698ebd0bc1595d86d91169410/dotnet-desktop-guide/framework/wpf/advanced/threading-model.md) | [Threading model](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/threading-model?branch=pr-en-us-1723&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->