### PR TITLE
Fix breadcrumbs

### DIFF
--- a/dotnet-desktop-guide/docfx.json
+++ b/dotnet-desktop-guide/docfx.json
@@ -127,7 +127,6 @@
     "externalReference": [],
     "globalMetadata": {
       "breadcrumb_path": "/dotnet/desktop/breadcrumb/toc.json",
-      "extendBreadcrumb": false,
       "feedback_system": "GitHub",
       "feedback_github_repo": "dotnet/docs-desktop",
       "feedback_product_url": "https://developercommunity.visualstudio.com/spaces/61/index.html",

--- a/dotnet-desktop-guide/framework/breadcrumb/toc.yml
+++ b/dotnet-desktop-guide/framework/breadcrumb/toc.yml
@@ -1,47 +1,10 @@
-items:
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: .NET
+  tocHref: /dotnet/
+  topicHref: /dotnet/index
   items:
-    - name: .NET
-      tocHref: /dotnet/
-      topicHref: /dotnet/index
-      items:
-      - name: Desktop Guide
-        tocHref: /dotnet/desktop
-        topicHref: /dotnet/desktop/index
-        items:
-        - name: .NET Framework
-          items:
-          - name: Windows Forms
-            tocHref: /dotnet/desktop/winforms
-            topicHref: /dotnet/desktop/winforms/index
-            items:
-            - name: Enhance Windows Forms applications
-              tocHref: /dotnet/desktop/winforms/advanced/
-              topicHref: /dotnet/desktop/winforms/advanced/index
-            - name: Controls
-              tocHref: /dotnet/desktop/winforms/controls/
-              topicHref: /dotnet/desktop/winforms/controls/index
-        - name: Windows Presentation Foundation
-          tocHref: /dotnet/desktop/wpf/
-          topicHref: /dotnet/desktop/wpf/index
-          items:
-          - name: Advanced
-            tocHref: /dotnet/desktop/wpf/advanced/
-            topicHref: /dotnet/desktop/wpf/advanced/index
-          - name: Application development
-            tocHref: /dotnet/desktop/wpf/app-development/
-            topicHref: /dotnet/desktop/wpf/app-development/index
-          - name: Controls
-            tocHref: /dotnet/desktop/wpf/controls/
-            topicHref: /dotnet/desktop/wpf/controls/index
-          - name: Data
-            tocHref: /dotnet/desktop/wpf/data/
-            topicHref: /dotnet/desktop/wpf/data/index
-          - name: Get started (WPF)
-            tocHref: /dotnet/desktop/wpf/getting-started/
-            topicHref: /dotnet/desktop/wpf/getting-started/index
-          - name: Graphics and multimedia
-            tocHref: /dotnet/desktop/wpf/graphics-multimedia/
-            topicHref: /dotnet/desktop/wpf/graphics-multimedia/index
+    - name: Windows Forms
+      tocHref: /dotnet/desktop/winforms
+      topicHref: /dotnet/desktop/winforms/index
+    - name: Windows Presentation Foundation
+      tocHref: /dotnet/desktop/wpf/
+      topicHref: /dotnet/desktop/wpf/index

--- a/dotnet-desktop-guide/framework/breadcrumb/toc.yml
+++ b/dotnet-desktop-guide/framework/breadcrumb/toc.yml
@@ -2,9 +2,9 @@
   tocHref: /dotnet/
   topicHref: /dotnet/index
   items:
-    - name: Windows Forms
-      tocHref: /dotnet/desktop/winforms
-      topicHref: /dotnet/desktop/winforms/index
-    - name: Windows Presentation Foundation
-      tocHref: /dotnet/desktop/wpf/
-      topicHref: /dotnet/desktop/wpf/index
+  - name: Windows Forms
+    tocHref: /dotnet/desktop/winforms
+    topicHref: /dotnet/desktop/winforms/index
+  - name: Windows Presentation Foundation
+    tocHref: /dotnet/desktop/wpf/
+    topicHref: /dotnet/desktop/wpf/index

--- a/dotnet-desktop-guide/net/breadcrumb/toc.yml
+++ b/dotnet-desktop-guide/net/breadcrumb/toc.yml
@@ -1,31 +1,11 @@
-items:
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: .NET
+  tocHref: /dotnet/
+  topicHref: /dotnet/index
   items:
-    - name: .NET
-      tocHref: /dotnet/
-      topicHref: /dotnet/index
-      items:
-      - name: Desktop Guide
-        tocHref: /dotnet/desktop
-        topicHref: /dotnet/desktop/index
-        items:
-        - name: ".NET 6"
-          items:
-          - name: Windows Forms
-            tocHref: /dotnet/desktop/winforms/
-            topicHref: /dotnet/desktop/winforms/index
-          - name: Windows Presentation Foundation
-            tocHref: /dotnet/desktop/wpf/
-            topicHref: /dotnet/desktop/wpf/index
-            items:
-            - name: Get started
-              tocHref: /visualstudio/get-started/csharp/tutorial-wpf
-              topicHref: /dotnet/desktop/wpf/getting-started/index
-            - name: Migration
-              tocHref: /dotnet/desktop/wpf/migration
-              topicHref: /dotnet/desktop/wpf/migration/index
-            - name: Data binding
-              tocHref: /dotnet/desktop/wpf/data
-              topicHref: /dotnet/desktop/wpf/data/index
+  - name: Windows Forms
+    tocHref: /dotnet/desktop/winforms/
+    topicHref: /dotnet/desktop/winforms/index
+  - name: Windows Presentation Foundation
+    tocHref: /dotnet/desktop/wpf/
+    topicHref: /dotnet/desktop/wpf/index
+

--- a/dotnet-desktop-guide/xaml-services/breadcrumb/toc.yml
+++ b/dotnet-desktop-guide/xaml-services/breadcrumb/toc.yml
@@ -1,16 +1,3 @@
-items:
-- name: Docs
-  tocHref: /
-  topicHref: /
-  items:
-    - name: .NET
-      tocHref: /dotnet/
-      topicHref: /dotnet/index
-      items:
-      - name: Desktop Guide
-        tocHref: /dotnet/desktop
-        topicHref: /dotnet/desktop/index
-        items:
-        - name: XAML Language Reference
-          tocHref: /dotnet/desktop/xaml-services
-          topicHref: /dotnet/desktop/xaml-services/index
+- name: .NET
+  tocHref: /dotnet/
+  topicHref: /dotnet/index


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 
