### PR TITLE
Fix issue with code casing in WPF overview

### DIFF
--- a/dotnet-desktop-guide/net/wpf/overview/index.md
+++ b/dotnet-desktop-guide/net/wpf/overview/index.md
@@ -163,7 +163,7 @@ End Namespace
 
 `InitializeComponent` is called from the code-behind class's constructor to merge the UI that is defined in markup with the code-behind class. (`InitializeComponent` is generated for you when your application is built, which is why you don't need to implement it manually.) The combination of `x:Class` and `InitializeComponent` ensure that your implementation is correctly initialized whenever it's created.
 
-Notice that in the markup the `<Button>` element defined a value of `button_click` for the `Click` attribute. With the markup and code-behind initialized and working together, the <xref:System.Windows.Controls.Primitives.ButtonBase.Click> event for the button is automatically mapped to the `button_click` method. When the button is clicked, the event handler is invoked and a message box is displayed by calling the <xref:System.Windows.MessageBox.Show%2A?displayProperty=fullName> method.
+Notice that in the markup the `<Button>` element defined a value of `button_Click` for the `Click` attribute. With the markup and code-behind initialized and working together, the <xref:System.Windows.Controls.Primitives.ButtonBase.Click> event for the button is automatically mapped to the `button_Click` method. When the button is clicked, the event handler is invoked and a message box is displayed by calling the <xref:System.Windows.MessageBox.Show%2A?displayProperty=fullName> method.
 
 The following figure shows the result when the button is clicked:
 


### PR DESCRIPTION

Fixes #1726


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/overview/index.md](https://github.com/dotnet/docs-desktop/blob/26464c2672cb9a67909cb2ee78a1bbd309c0384a/dotnet-desktop-guide/net/wpf/overview/index.md) | [Desktop Guide (WPF .NET)](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/overview/index?branch=pr-en-us-1730&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->