### PR TITLE
Update freezable-objects-overview.md

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/freezable-objects-overview.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/freezable-objects-overview.md
@@ -100,7 +100,7 @@ To use the `Freeze` attribute, you must map to the presentation options namespac
 xmlns:PresentationOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
 ```
 
-Because not all XAML readers recognize this attribute, it's recommended that you use the [mc:Ignorable Attribute](mc-ignorable-attribute.md) to mark the `Presentation:Freeze` attribute as ignorable:
+Because not all XAML readers recognize this attribute, it's recommended that you use the [mc:Ignorable Attribute](mc-ignorable-attribute.md) to mark the `PresentationOptions:Freeze` attribute as ignorable:
 
 ```xaml
 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"


### PR DESCRIPTION
Fix namespace in inline code snippet for consistency

## Summary

The code recommends using the namespace `PresentationOptions`, and does use that throughout the examples. But this inline snippet uses `Presentation` instead of `PresentationOptions`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/advanced/freezable-objects-overview.md](https://github.com/dotnet/docs-desktop/blob/9a9a1c74e8a0df85c960bec0854f63e4e75fb5af/dotnet-desktop-guide/framework/wpf/advanced/freezable-objects-overview.md) | [Freezable Objects Overview](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/freezable-objects-overview?branch=pr-en-us-1745&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->