### PR TITLE
Remove VB Warning

### DIFF
--- a/dotnet-desktop-guide/net/winforms/migration/index.md
+++ b/dotnet-desktop-guide/net/winforms/migration/index.md
@@ -15,9 +15,6 @@ This article describes how to upgrade a Windows Forms desktop app to .NET 7. Eve
 
 You should also review the information in the [Porting from .NET Framework to .NET](/dotnet/core/porting/) guide.
 
-> [!WARNING]
-> Don't upgrade Visual Basic Windows Forms projects. There seems to be a bug with the extension. This article will be updated when the bug is fixed.
-
 ## Prerequisites
 
 - Windows Operating System


### PR DESCRIPTION
The warning is no longer needed

## Summary

Just removed a warning about migrating with VB .NET.

Fixes #Issue_Number (if available)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/winforms/migration/index.md](https://github.com/dotnet/docs-desktop/blob/aa745f93fe19fda7672b10828235b14db1045286/dotnet-desktop-guide/net/winforms/migration/index.md) | [How to upgrade a Windows Forms desktop app to .NET 7](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/migration/index?branch=pr-en-us-1767&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->