### PR TITLE
Try to fix italian translation related to binding

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/templatebinding-markup-extension.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/templatebinding-markup-extension.md
@@ -36,7 +36,7 @@ Links the value of a property in a control template to be the value of another p
   
 ## Remarks  
 
- A `TemplateBinding` is an optimized form of a [Binding](binding-markup-extension.md) for template scenarios, analogous to a `Binding` constructed with `{Binding RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}`. A `TemplateBinding` is always a one-way binding, even if properties involved default to two-way binding. Both properties involved must be dependency properties. In order to achieve two-way binding to a templated parent use the following binding statement instead
+ A `TemplateBinding` is an optimized form of a [`Binding`](binding-markup-extension.md) for template scenarios, analogous to a `Binding` constructed with `{Binding RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}`. A `TemplateBinding` is always a one-way binding, even if properties involved default to two-way binding. Both properties involved must be dependency properties. In order to achieve two-way binding to a templated parent use the following binding statement instead
 `{Binding RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay, Path=MyDependencyProperty}`.
   
  [RelativeSource](relativesource-markupextension.md) is another markup extension that is sometimes used in conjunction with or instead of `TemplateBinding` in order to perform relative property binding within a template.  


### PR DESCRIPTION
## Summary

- Put the binding link text inside a code block to prevent translation

Fixes #1762


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/advanced/templatebinding-markup-extension.md](https://github.com/dotnet/docs-desktop/blob/ec219655c2b77e27983ebdc43f4172b417d4168e/dotnet-desktop-guide/framework/wpf/advanced/templatebinding-markup-extension.md) | [TemplateBinding Markup Extension](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/templatebinding-markup-extension?branch=pr-en-us-1781&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->