### PR TITLE
Update some tables to prevent loc

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/controls/styles-templates-overview.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/styles-templates-overview.md
@@ -170,12 +170,12 @@ Controls are always in a specific **state**. For example, when the mouse moves o
 
 | VisualState Name | VisualStateGroup Name | Description |
 | ---------------- | --------------------- | ----------- |
-| Normal           | CommonStates          | The default state. |
-| MouseOver        | CommonStates          | The mouse pointer is positioned over the control. |
-| Pressed          | CommonStates          | The control is pressed. |
-| Disabled         | CommonStates          | The control is disabled. |
-| Focused          | FocusStates           | The control has focus. |
-| Unfocused        | FocusStates           | The control does not have focus. |
+| `Normal`         | `CommonStates`        | The default state. |
+| `MouseOver`      | `CommonStates`        | The mouse pointer is positioned over the control. |
+| `Pressed`        | `CommonStates`        | The control is pressed. |
+| `Disabled`       | `CommonStates`        | The control is disabled. |
+| `Focused`        | `FocusStates`         | The control has focus. |
+| `Unfocused`      | `FocusStates`         | The control does not have focus. |
 
 By defining a <xref:System.Windows.VisualStateManager?displayProperty=fullName> on the root element of a control template, you can trigger animations when a control enters a specific state. The `VisualStateManager` declares which combinations of <xref:System.Windows.VisualStateGroup> and <xref:System.Windows.VisualState> to watch. When the control enters a watched state, the animation defined by the `VisualStateManager` is started.
 

--- a/dotnet-desktop-guide/net/wpf/controls/styles-templates-overview.md
+++ b/dotnet-desktop-guide/net/wpf/controls/styles-templates-overview.md
@@ -174,12 +174,12 @@ Controls are always in a specific **state**. For example, when the mouse moves o
 
 | VisualState Name | VisualStateGroup Name | Description |
 | ---------------- | --------------------- | ----------- |
-| Normal           | CommonStates          | The default state. |
-| MouseOver        | CommonStates          | The mouse pointer is positioned over the control. |
-| Pressed          | CommonStates          | The control is pressed. |
-| Disabled         | CommonStates          | The control is disabled. |
-| Focused          | FocusStates           | The control has focus. |
-| Unfocused        | FocusStates           | The control does not have focus. |
+| `Normal`         | `CommonStates`        | The default state. |
+| `MouseOver`      | `CommonStates`        | The mouse pointer is positioned over the control. |
+| `Pressed`        | `CommonStates`        | The control is pressed. |
+| `Disabled`       | `CommonStates`        | The control is disabled. |
+| `Focused`        | `FocusStates`         | The control has focus. |
+| `Unfocused`      | `FocusStates`         | The control does not have focus. |
 
 By defining a <xref:System.Windows.VisualStateManager?displayProperty=fullName> on the root element of a control template, you can trigger animations when a control enters a specific state. The `VisualStateManager` declares which combinations of <xref:System.Windows.VisualStateGroup> and <xref:System.Windows.VisualState> to watch. When the control enters a watched state, the animation defined by the `VisualStateManager` is started.
 

--- a/dotnet-desktop-guide/net/wpf/migration/differences-from-net-framework.md
+++ b/dotnet-desktop-guide/net/wpf/migration/differences-from-net-framework.md
@@ -1,6 +1,6 @@
 ---
 title: Differences between .NET Framework and .NET
-description: Describes the differences between the .NET Framework implementation of Windows Presentation Foundation (WPF) and .NET WPF. When migrating your app, you should consider these incompatibilities.
+description: Describes the differences between the .NET Framework implementation of Windows Presentation Foundation (WPF) and .NET WPF.
 author: adegeo
 ms.date: 02/15/2023
 ms.author: adegeo
@@ -26,7 +26,7 @@ If your .NET Framework app lists its NuGet dependencies in a *packages.config* f
 01. In Visual Studio, open the **Solution Explorer** pane.
 01. In your WPF project, right-click **packages.config** > **Migrate packages.config to PackageReference**.
 
-:::image type="content" source="media/differences-from-net-framework/package-reference-migration.png" alt-text="Upgrading to PackageReference.":::
+:::image type="content" source="media/differences-from-net-framework/package-reference-migration.png" alt-text="The Solution Explorer's context menu in Visual Studio, displaying the 'Migrate packages.config' item.":::
 
 A dialog will appear showing calculated top-level NuGet dependencies and asking which other NuGet packages should be promoted to top level. Select **OK** and the *packages.config* file will be removed from the project and `<PackageReference>` elements will be added to the project file.
 
@@ -40,9 +40,9 @@ Publicly defined CAS-related types were moved out of the WPF assemblies and into
 
 | Source assembly | Target assembly | Type                |
 | --------------- | --------------- | ------------------- |
-| *WindowsBase.dll* | *System.Security.Permissions.dll* | <xref:System.Security.Permissions.MediaPermission> <br /> <xref:System.Security.Permissions.MediaPermissionAttribute> <br /> <xref:System.Security.Permissions.MediaPermissionAudio> <br /> <xref:System.Security.Permissions.MediaPermissionImage> <br /> <xref:System.Security.Permissions.MediaPermissionVideo> <br /> <xref:System.Security.Permissions.WebBrowserPermission> <br /> <xref:System.Security.Permissions.WebBrowserPermissionAttribute> <br /> <xref:System.Security.Permissions.WebBrowserPermissionLevel> |
-| *System.Xaml.dll* | *System.Security.Permissions.dll* | <xref:System.Xaml.Permissions.XamlLoadPermission> |
-| *System.Xaml.dll* | *System.Windows.Extension.dll*    | <xref:System.Xaml.Permissions.XamlAccessLevel><br/> |
+| `WindowsBase.dll` | `System.Security.Permissions.dll` | <xref:System.Security.Permissions.MediaPermission> <br /> <xref:System.Security.Permissions.MediaPermissionAttribute> <br /> <xref:System.Security.Permissions.MediaPermissionAudio> <br /> <xref:System.Security.Permissions.MediaPermissionImage> <br /> <xref:System.Security.Permissions.MediaPermissionVideo> <br /> <xref:System.Security.Permissions.WebBrowserPermission> <br /> <xref:System.Security.Permissions.WebBrowserPermissionAttribute> <br /> <xref:System.Security.Permissions.WebBrowserPermissionLevel> |
+| `System.Xaml.dll` | `System.Security.Permissions.dll` | <xref:System.Xaml.Permissions.XamlLoadPermission> |
+| `System.Xaml.dll` | `System.Windows.Extension.dll`    | <xref:System.Xaml.Permissions.XamlAccessLevel><br/> |
 
 > [!NOTE]
 > In order to minimize porting friction, the functionality for storing and retrieving information related to the following properties was retained in the `XamlAccessLevel` type.

--- a/dotnet-desktop-guide/net/wpf/migration/differences-from-net-framework.md
+++ b/dotnet-desktop-guide/net/wpf/migration/differences-from-net-framework.md
@@ -40,9 +40,9 @@ Publicly defined CAS-related types were moved out of the WPF assemblies and into
 
 | Source assembly | Target assembly | Type                |
 | --------------- | --------------- | ------------------- |
-| `WindowsBase.dll` | `System.Security.Permissions.dll` | <xref:System.Security.Permissions.MediaPermission> <br /> <xref:System.Security.Permissions.MediaPermissionAttribute> <br /> <xref:System.Security.Permissions.MediaPermissionAudio> <br /> <xref:System.Security.Permissions.MediaPermissionImage> <br /> <xref:System.Security.Permissions.MediaPermissionVideo> <br /> <xref:System.Security.Permissions.WebBrowserPermission> <br /> <xref:System.Security.Permissions.WebBrowserPermissionAttribute> <br /> <xref:System.Security.Permissions.WebBrowserPermissionLevel> |
-| `System.Xaml.dll` | `System.Security.Permissions.dll` | <xref:System.Xaml.Permissions.XamlLoadPermission> |
-| `System.Xaml.dll` | `System.Windows.Extension.dll`    | <xref:System.Xaml.Permissions.XamlAccessLevel><br/> |
+| WindowsBase.dll | System.Security.Permissions.dll | <xref:System.Security.Permissions.MediaPermission> <br /> <xref:System.Security.Permissions.MediaPermissionAttribute> <br /> <xref:System.Security.Permissions.MediaPermissionAudio> <br /> <xref:System.Security.Permissions.MediaPermissionImage> <br /> <xref:System.Security.Permissions.MediaPermissionVideo> <br /> <xref:System.Security.Permissions.WebBrowserPermission> <br /> <xref:System.Security.Permissions.WebBrowserPermissionAttribute> <br /> <xref:System.Security.Permissions.WebBrowserPermissionLevel> |
+| System.Xaml.dll | System.Security.Permissions.dll | <xref:System.Xaml.Permissions.XamlLoadPermission> |
+| System.Xaml.dll | System.Windows.Extension.dll    | <xref:System.Xaml.Permissions.XamlAccessLevel><br/> |
 
 > [!NOTE]
 > In order to minimize porting friction, the functionality for storing and retrieving information related to the following properties was retained in the `XamlAccessLevel` type.


### PR DESCRIPTION
## Summary

- Updated a few tables that were having properties translated.
- Fix a couple descriptions

Fixes #1790


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/controls/styles-templates-overview.md](https://github.com/dotnet/docs-desktop/blob/620409fa65601e2f7c288e5ce127aad9416c62fe/dotnet-desktop-guide/framework/wpf/controls/styles-templates-overview.md) | [Styles and templates in WPF](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/styles-templates-overview?branch=pr-en-us-1810&view=netframeworkdesktop-4.8) |
| [dotnet-desktop-guide/net/wpf/controls/styles-templates-overview.md](https://github.com/dotnet/docs-desktop/blob/620409fa65601e2f7c288e5ce127aad9416c62fe/dotnet-desktop-guide/net/wpf/controls/styles-templates-overview.md) | [Styles and templates](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/styles-templates-overview?branch=pr-en-us-1810&view=netdesktop-7.0) |
| [dotnet-desktop-guide/net/wpf/migration/differences-from-net-framework.md](https://github.com/dotnet/docs-desktop/blob/620409fa65601e2f7c288e5ce127aad9416c62fe/dotnet-desktop-guide/net/wpf/migration/differences-from-net-framework.md) | [Differences with WPF .NET](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/migration/differences-from-net-framework?branch=pr-en-us-1810&view=netdesktop-7.0) |

<!-- PREVIEW-TABLE-END -->