### PR TITLE
Add step to change base class

### DIFF
--- a/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
+++ b/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
@@ -1,7 +1,7 @@
 ---
 title: Customize an existing control
 description: Learn how to inherit from existing controls so that another control has all of its functionality and visual properties.
-ms.date: 06/01/2023
+ms.date: 04/30/2024
 dev_langs:
   - "csharp"
   - "vb"
@@ -9,6 +9,7 @@ helpviewer_keywords:
   - "inheritance [Windows Forms], Windows Forms custom controls"
   - "custom controls [Windows Forms], inheritance"
 ---
+
 # Extend an existing control
 
 If you want to add more features to an existing control, you can create a control that inherits from an existing control. The new control contains all of the capabilities and visual aspect of the base control, but gives you opportunity to extend it. For example, if you created a control that inherits <xref:System.Windows.Forms.Button>, your new control would look and act exactly like a button. You could create new methods and properties to customize the behavior of the control. Some controls allow you to override the <xref:System.Windows.Forms.Control.OnPaint%2A> method to change the way the control looks.
@@ -41,7 +42,11 @@ After [you add a custom control to your project](#add-a-custom-control-to-a-proj
     :::code language="csharp" source="./snippets/extend-existing/csharp/CustomControl2.cs" id="control":::
     :::code language="vb" source="./snippets/extend-existing/vb/CustomControl2.vb" id="control":::
 
-01. First, add a class-scoped variable named `_counter`.
+01. Change the base class from `Control` to `Button`.
+
+    If you're using Visual Basic, you need to open the _\*.designer.vb_ file of your control and set the base class to `System.Windows.Forms.Button`.
+
+01. Add a class-scoped variable named `_counter`.
 
     :::code language="csharp" source="./snippets/extend-existing/csharp/CustomControl1.cs" id="counter":::
     :::code language="vb" source="./snippets/extend-existing/vb/CustomControl1.vb" id="counter":::

--- a/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
+++ b/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
@@ -45,7 +45,7 @@ After [you add a custom control to your project](#add-a-custom-control-to-a-proj
 01. Change the base class from `Control` to `Button`.
 
     > [!IMPORTANT]
-    > If you're using Visual Basic, the base class is defined in the _\*.designer.vb_ file of your control. The base class to use in Visual Basic is `System.Windows.Forms.Button`.
+    > If you're using **Visual Basic**, the base class is defined in the _\*.designer.vb_ file of your control. The base class to use in Visual Basic is `System.Windows.Forms.Button`.
 
 01. Add a class-scoped variable named `_counter`.
 

--- a/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
+++ b/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
@@ -44,7 +44,8 @@ After [you add a custom control to your project](#add-a-custom-control-to-a-proj
 
 01. Change the base class from `Control` to `Button`.
 
-    If you're using Visual Basic, the base class is defined in the _\*.designer.vb_ file of your control. Open that file and set the base class to `System.Windows.Forms.Button`.
+    > [!IMPORTANT]
+    > If you're using Visual Basic, the base class is defined in the _\*.designer.vb_ file of your control. The base class to use in Visual Basic is `System.Windows.Forms.Button`.
 
 01. Add a class-scoped variable named `_counter`.
 

--- a/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
+++ b/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md
@@ -44,7 +44,7 @@ After [you add a custom control to your project](#add-a-custom-control-to-a-proj
 
 01. Change the base class from `Control` to `Button`.
 
-    If you're using Visual Basic, you need to open the _\*.designer.vb_ file of your control and set the base class to `System.Windows.Forms.Button`.
+    If you're using Visual Basic, the base class is defined in the _\*.designer.vb_ file of your control. Open that file and set the base class to `System.Windows.Forms.Button`.
 
 01. Add a class-scoped variable named `_counter`.
 
@@ -66,6 +66,6 @@ After [you add a custom control to your project](#add-a-custom-control-to-a-proj
     :::code language="csharp" source="./snippets/extend-existing/csharp/CustomControl1.cs" id="control":::
     :::code language="vb" source="./snippets/extend-existing/vb/CustomControl1.vb" id="control":::
 
-Now that the control is created, compile the project to populate the **Toolbox** window with the new control. Open a form designer and drag the control to the form. When you run the project and click the button, you'll see that it counts the clicks and paints the text on top of the button.
+Now that the control is created, compile the project to populate the **Toolbox** window with the new control. Open a form designer and drag the control to the form. Run the project and press the button. Each press increases the number of clicks by one. The total clicks are printed as text on top of the button.
 
 :::image type="content" source="media/extend-existing/toolbox.png" alt-text="Visual Studio Toolbox window for Windows Forms showing a custom control.":::

--- a/dotnet-desktop-guide/net/winforms/controls-design/snippets/extend-existing/csharp/CustomControlProject.csproj
+++ b/dotnet-desktop-guide/net/winforms/controls-design/snippets/extend-existing/csharp/CustomControlProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/dotnet-desktop-guide/net/winforms/controls-design/snippets/extend-existing/vb/CustomControlProjectVB.vbproj
+++ b/dotnet-desktop-guide/net/winforms/controls-design/snippets/extend-existing/vb/CustomControlProjectVB.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <StartupObject>Sub Main</StartupObject>
     <UseWindowsForms>true</UseWindowsForms>
     <MyType>WindowsForms</MyType>
@@ -13,10 +13,6 @@
     <Import Include="System.Data" />
     <Import Include="System.Drawing" />
     <Import Include="System.Windows.Forms" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\csharp\CustomControlProject.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Added a step that talks about changing the base class from `Control` to `Button`.
- Updated project from net7 to net8.

Fixes #1787

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md](https://github.com/dotnet/docs-desktop/blob/710a9b7fb6cd58e2c2f08ce15cdbd2eeb5c43c87/dotnet-desktop-guide/net/winforms/controls-design/extend-existing.md) | [Extend an existing control](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls-design/extend-existing?branch=pr-en-us-1819&view=netdesktop-7.0) |


<!-- PREVIEW-TABLE-END -->