### PR TITLE
Fix article using the wrong variable name

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/data/how-to-bind-to-a-method.md
+++ b/dotnet-desktop-guide/framework/wpf/data/how-to-bind-to-a-method.md
@@ -26,7 +26,7 @@ The following example shows how to bind to a method using <xref:System.Windows.D
   
  The converter `DoubleToString` takes a double and turns it into a string in the <xref:System.Windows.Data.IValueConverter.Convert%2A> direction (from the binding source to binding target, which is the <xref:System.Windows.Controls.TextBox.Text%2A> property) and converts a `string` to a `double` in the <xref:System.Windows.Data.IValueConverter.ConvertBack%2A> direction.  
   
- The `InvalidationCharacterRule` is a <xref:System.Windows.Controls.ValidationRule> that checks for invalid characters. The default error template, which is a red border around the <xref:System.Windows.Controls.TextBox>, appears to notify users when the input value is not a double value.  
+ The `InvalidCharacterRule` is a <xref:System.Windows.Controls.ValidationRule> that checks for invalid characters. The default error template, which is a red border around the <xref:System.Windows.Controls.TextBox>, appears to notify users when the input value is not a double value.  
   
 ## See also
 


### PR DESCRIPTION
## Summary

- Fix the variable name

Fixes #1814

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/data/how-to-bind-to-a-method.md](https://github.com/dotnet/docs-desktop/blob/37f202d0ca151f019cbbd80ff99b46135bff527b/dotnet-desktop-guide/framework/wpf/data/how-to-bind-to-a-method.md) | [How to: Bind to a Method](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-bind-to-a-method?branch=pr-en-us-1836&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->