### PR TITLE
Clarify that the LINE command in SVG can specify multiple points

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
@@ -91,17 +91,17 @@ Paths are discussed in [Shapes and Basic Drawing in WPF Overview](shapes-and-bas
   
 ### Line Command  
 
- Creates a straight line between the current point and the specified end point. `l 20 30` and `L 20,30` are examples of valid **line** commands.  
+Creates a straight line from the current point to the specified point. More than one point can be specified, with a line being drawn sequentially between each point. `l 20 30`,  `L 20,30`, and `L 20,30 25,35` are examples of valid **line** commands.
   
 |Syntax|  
 |------------|  
-|`L` *endPoint*<br /><br /> - or -<br /><br /> `l` *endPoint*|  
+|`L` *point* [*point* ...]<br /><br /> - or -<br /><br /> `l` *point* [*point* ...]|  
   
 |Term|Description|  
 |----------|-----------------|  
-|*endPoint*|<xref:System.Windows.Point?displayProperty=nameWithType><br /><br /> The end point of the line.|  
+|*point*|<xref:System.Windows.Point?displayProperty=nameWithType><br /><br /> The next point to draw a line to.|  
 
-An uppercase `L` indicates that `endPoint` is an absolute value; a lowercase `l` indicates that `endPoint` is an offset to the previous point, or (0,0) if none exists.
+An uppercase `L` indicates that `point` is an absolute value; a lowercase `l` indicates that `point` is an offset to the previous point, or (0,0) if none exists.
 
 ### Horizontal Line Command  
 

--- a/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
@@ -87,21 +87,24 @@ Paths are discussed in [Shapes and Basic Drawing in WPF Overview](shapes-and-bas
 
  A draw command can consist of several shape commands. The following shape commands are available: line, horizontal line, vertical line, cubic Bezier curve, quadratic Bezier curve, smooth cubic Bezier curve, smooth quadratic Bezier curve, and elliptical arc.  
   
- You enter each command by using either an uppercase or a lowercase letter: uppercase letters denote absolute values and lowercase letters denote relative values: the control points for that segment are relative to the end point of the preceding example. When sequentially entering more than one command of the same type, you can omit the duplicate command entry; for example, `L 100,200 300,400` is equivalent to `L 100,200 L 300,400`. The following table describes the **move** and **draw** commands.  
+ You enter each command by using either an uppercase or a lowercase letter: uppercase letters denote absolute values and lowercase letters denote relative values: the control points for that segment are relative to the end point of the preceding example.
+
+> [!TIP]
+> When sequentially entering more than one command of the same type, you can omit the duplicate command entry; for example, `L 100,200 300,400` is equivalent to `L 100,200 L 300,400`. The following table describes the **move** and **draw** commands.
   
 ### Line Command  
 
-Creates a straight line from the current point to the specified point. More than one point can be specified, with a line being drawn sequentially between each point. `l 20 30`,  `L 20,30`, and `L 20,30 25,35` are examples of valid **line** commands.
+Creates a straight line between the current point and the specified end point. `l 20 30` and `L 20,30` are examples of valid **line** commands.
   
 |Syntax|  
 |------------|  
-|`L` *point* [*point* ...]<br /><br /> - or -<br /><br /> `l` *point* [*point* ...]|  
+|`L` *endPoint*<br /><br /> - or -<br /><br /> `l` *endPoint*|  
   
 |Term|Description|  
 |----------|-----------------|  
-|*point*|<xref:System.Windows.Point?displayProperty=nameWithType><br /><br /> The next point to draw a line to.|  
+|*endPoint*|<xref:System.Windows.Point?displayProperty=nameWithType><br /><br /> The end point of the line.|  
 
-An uppercase `L` indicates that `point` is an absolute value; a lowercase `l` indicates that `point` is an offset to the previous point, or (0,0) if none exists.
+An uppercase `L` indicates that `endPoint` is an absolute value; a lowercase `l` indicates that `endPoint` is an offset to the previous point, or (0,0) if none exists.
 
 ### Horizontal Line Command  
 

--- a/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
+++ b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md
@@ -90,7 +90,7 @@ Paths are discussed in [Shapes and Basic Drawing in WPF Overview](shapes-and-bas
  You enter each command by using either an uppercase or a lowercase letter: uppercase letters denote absolute values and lowercase letters denote relative values: the control points for that segment are relative to the end point of the preceding example.
 
 > [!TIP]
-> When sequentially entering more than one command of the same type, you can omit the duplicate command entry; for example, `L 100,200 300,400` is equivalent to `L 100,200 L 300,400`. The following table describes the **move** and **draw** commands.
+> When sequentially entering more than one command of the same type, you can omit the duplicate command entry; for example, `L 100,200 300,400` is equivalent to `L 100,200 L 300,400`.
   
 ### Line Command  
 


### PR DESCRIPTION
## Summary

Describe your changes here.

Fixes #1805


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md](https://github.com/dotnet/docs-desktop/blob/e278edd88a6a433e483cd0bd16d5c79560f46885/dotnet-desktop-guide/framework/wpf/graphics-multimedia/path-markup-syntax.md) | [Path Markup Syntax](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/graphics-multimedia/path-markup-syntax?branch=pr-en-us-1841&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->