### PR TITLE
Add link about tech region limitations in WPF

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/technology-regions-overview.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/technology-regions-overview.md
@@ -56,7 +56,9 @@ If multiple presentation technologies are used in an application, such as WPF, W
 - WPF supports hardware accelerated layered windows.  
   
 - WPF does not support transparency color keys, because WPF cannot guarantee to render the exact color you requested, particularly when rendering is hardware-accelerated.  
-  
+
+For more information regarding the limitations of interop regions, see [HWNDs inside WPF](wpf-and-win32-interoperation.md#hwnds-inside-wpf).
+
 ## See also
 
 - [WPF and Win32 Interoperation](wpf-and-win32-interoperation.md)


### PR DESCRIPTION
## Summary

- Add link to the main overview that has a list of things to consider regarding HWND hosts in WPF.

Fixes #1601


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/advanced/technology-regions-overview.md](https://github.com/dotnet/docs-desktop/blob/8c48c1045d4402f1702898bf058932dd89d66a61/dotnet-desktop-guide/framework/wpf/advanced/technology-regions-overview.md) | [Technology Regions Overview](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/technology-regions-overview?branch=pr-en-us-1848&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->