### PR TITLE
Correct shape example in WPF

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/graphics-multimedia/how-to-create-a-shape-using-a-streamgeometry.md
+++ b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/how-to-create-a-shape-using-a-streamgeometry.md
@@ -39,8 +39,8 @@ ms.assetid: 08f7c8ce-074b-49cd-9aba-cc9592d4ee51
   
 ## See also
 
+- [Create a Shape by Using a PathGeometry](how-to-create-a-shape-by-using-a-pathgeometry.md)
+- [Geometry Overview](geometry-overview.md)
 - <xref:System.Windows.Media.PathGeometry>
 - <xref:System.Windows.Media.StreamGeometry>
 - <xref:System.Windows.Media.StreamGeometryContext>
-- [Create a Shape by Using a PathGeometry](how-to-create-a-shape-by-using-a-pathgeometry.md)
-- [Geometry Overview](geometry-overview.md)

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/GeometriesMiscSnippets_procedural_snip/CSharp/StreamGeometryExample.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/GeometriesMiscSnippets_procedural_snip/CSharp/StreamGeometryExample.cs
@@ -44,8 +44,6 @@ namespace SDKSample
 
             using (StreamGeometryContext ctx = geometry.Open())
             {
-                ctx.BeginFigure(new Point(), true /* is filled */, true /* is closed */);
-
                 double step = 2 * Math.PI / Math.Max(numSides, 3);
                 Point cur = c;
 
@@ -54,7 +52,10 @@ namespace SDKSample
                 {
                     cur.X = c.X + r * Math.Cos(a);
                     cur.Y = c.Y + r * Math.Sin(a);
-                    ctx.LineTo(cur, true /* is stroked */, false /* is smooth join */);
+                    if (i == 0)
+                        ctx.BeginFigure(cur, true /* is filled */, true /* is closed */);
+                    else
+                        ctx.LineTo(cur, true /* is stroked */, false /* is smooth join */);
                 }
             }
 

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/GeometriesMiscSnippets_procedural_snip/visualbasic/streamgeometryexample.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/GeometriesMiscSnippets_procedural_snip/visualbasic/streamgeometryexample.vb
@@ -6,58 +6,62 @@ Imports System.Windows.Media
 Imports System.Windows.Shapes
 
 Namespace SDKSample
-	Partial Public Class StreamGeometryExample
-		Inherits Page
-		Public Sub New()
-			' Create a path to draw a geometry with.
-			Dim myPath As New Path()
-			myPath.Stroke = Brushes.Black
-			myPath.StrokeThickness = 1
+    Partial Public Class StreamGeometryExample
+        Inherits Page
+        Public Sub New()
+            ' Create a path to draw a geometry with.
+            Dim myPath As New Path()
+            myPath.Stroke = Brushes.Black
+            myPath.StrokeThickness = 1
 
-			' Create a StreamGeometry to use to specify myPath.
-			Dim theGeometry As StreamGeometry = BuildRegularPolygon(New Point(200, 200), 200, 8, 0)
-			theGeometry.FillRule = FillRule.EvenOdd
+            ' Create a StreamGeometry to use to specify myPath.
+            Dim theGeometry As StreamGeometry = BuildRegularPolygon(New Point(200, 200), 200, 8, 0)
+            theGeometry.FillRule = FillRule.EvenOdd
 
-			' Freeze the geometry (make it unmodifiable)
-			' for additional performance benefits.
-			theGeometry.Freeze()
+            ' Freeze the geometry (make it unmodifiable)
+            ' for additional performance benefits.
+            theGeometry.Freeze()
 
-			' Use the StreamGeometry returned by the BuildRegularPolygon to 
-			' specify the shape of the path.
-			myPath.Data = theGeometry
+            ' Use the StreamGeometry returned by the BuildRegularPolygon to 
+            ' specify the shape of the path.
+            myPath.Data = theGeometry
 
-			' Add path shape to the UI.
-			Dim mainPanel As New StackPanel()
-			mainPanel.Children.Add(myPath)
-			Me.Content = mainPanel
-		End Sub
+            ' Add path shape to the UI.
+            Dim mainPanel As New StackPanel()
+            mainPanel.Children.Add(myPath)
+            Me.Content = mainPanel
+        End Sub
 
-		Private Function BuildRegularPolygon(ByVal c As Point, ByVal r As Double, ByVal numSides As Integer, ByVal offsetDegree As Double) As StreamGeometry
-			' c is the center, r is the radius,
-			' numSides the number of sides, offsetDegree the offset in Degrees.
-			' Do not add the last point.
+        Private Function BuildRegularPolygon(ByVal c As Point, ByVal r As Double, ByVal numSides As Integer, ByVal offsetDegree As Double) As StreamGeometry
+            ' c is the center, r is the radius,
+            ' numSides the number of sides, offsetDegree the offset in Degrees.
+            ' Do not add the last point.
 
-			Dim geometry As New StreamGeometry()
+            Dim geometry As New StreamGeometry()
 
-			Using ctx As StreamGeometryContext = geometry.Open()
-				ctx.BeginFigure(New Point(), True, True) ' is closed  -  is filled 
+            Using ctx As StreamGeometryContext = geometry.Open()
 
-				Dim [step] As Double = 2 * Math.PI / Math.Max(numSides, 3)
-				Dim cur As Point = c
+                Dim [step] As Double = 2 * Math.PI / Math.Max(numSides, 3)
+                Dim cur As Point = c
 
-				Dim a As Double = Math.PI * offsetDegree / 180.0
-				Dim i As Integer = 0
-				Do While i < numSides
-					cur.X = c.X + r * Math.Cos(a)
-					cur.Y = c.Y + r * Math.Sin(a)
-					ctx.LineTo(cur, True, False) ' is smooth join  -  is stroked 
-					i += 1
-					a += [step]
-				Loop
-			End Using
+                Dim a As Double = Math.PI * offsetDegree / 180.0
+                Dim i As Integer = 0
 
-			Return geometry
-		End Function
-	End Class
+                For i = 0 To numSides - 1
+                    cur.X = c.X + r * Math.Cos(a)
+                    cur.Y = c.Y + r * Math.Sin(a)
+                    If i = 0 Then
+                        ctx.BeginFigure(cur, True, True) ' is closed  -  is filled 
+                    Else
+                        ctx.LineTo(cur, True, False) ' is smooth join  -  is stroked 
+                    End If
+                    a += [step]
+                Next
+
+            End Using
+
+            Return geometry
+        End Function
+    End Class
 End Namespace
 ' </SnippetStreamGeometryExampleWholePage>


### PR DESCRIPTION
## Summary

The shape code was drawing a bad polygon. The example submitted by a customer fixed it. This PR implements that fix.

Fixes #1358


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/graphics-multimedia/how-to-create-a-shape-using-a-streamgeometry.md](https://github.com/dotnet/docs-desktop/blob/1ee0d3d8eb2b4722a0504978eac411e703d54ce9/dotnet-desktop-guide/framework/wpf/graphics-multimedia/how-to-create-a-shape-using-a-streamgeometry.md) | [How to: Create a Shape Using a StreamGeometry](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/graphics-multimedia/how-to-create-a-shape-using-a-streamgeometry?branch=pr-en-us-1853&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->