### PR TITLE
Fix WPF markup to match screenshot

### DIFF
--- a/dotnet-desktop-guide/net/wpf/overview/index.md
+++ b/dotnet-desktop-guide/net/wpf/overview/index.md
@@ -97,7 +97,7 @@ The main behavior of an application is to implement the functionality that respo
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     x:Class="SDKSample.AWindow"
-    Title="Window with Button"
+    Title="Window with button"
     Width="250" Height="100">
 
   <!-- Add button to window -->

--- a/dotnet-desktop-guide/net/wpf/overview/index.md
+++ b/dotnet-desktop-guide/net/wpf/overview/index.md
@@ -71,7 +71,7 @@ The following example uses XAML to implement the appearance of a window that con
 ```xaml
 <Window
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    Title="Window with Button"
+    Title="Window with button"
     Width="250" Height="100">
 
   <!-- Add button to window -->


### PR DESCRIPTION
## Summary

Change code to match screenshot

Fixes #1399


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/overview/index.md](https://github.com/dotnet/docs-desktop/blob/460a2f71366c04d8ab99cb8ca8669502a8205c36/dotnet-desktop-guide/net/wpf/overview/index.md) | [Desktop Guide (WPF .NET)](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/overview/index?branch=pr-en-us-1854&view=netdesktop-7.0) |


<!-- PREVIEW-TABLE-END -->