### PR TITLE
WPF shape article doesn't call out the namespaces used.

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/graphics-multimedia/shapes-and-basic-drawing-in-wpf-overview.md
+++ b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/shapes-and-basic-drawing-in-wpf-overview.md
@@ -20,6 +20,8 @@ This topic gives an overview of how to draw with <xref:System.Windows.Shapes.Sha
   
  Windows Presentation Foundation (WPF) offers several layers of access to graphics and rendering services. At the top layer, <xref:System.Windows.Shapes.Shape> objects are easy to use and provide many useful features, such as layout and participation in the Windows Presentation Foundation (WPF) event system.  
 
+Shape-related types are in the `Windows.Shapes` namespace. Geometry-related types are in the `System.Windows.Media` namespace.
+
 <a name="shapes"></a>
 
 ## Shape Objects  


### PR DESCRIPTION
## Summary

Add two namespaces to intro.

Fixes #1511


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/graphics-multimedia/shapes-and-basic-drawing-in-wpf-overview.md](https://github.com/dotnet/docs-desktop/blob/886da0603cb4c9543f11092613b92e9089bbfc9b/dotnet-desktop-guide/framework/wpf/graphics-multimedia/shapes-and-basic-drawing-in-wpf-overview.md) | [Shapes and Basic Drawing in WPF Overview](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/graphics-multimedia/shapes-and-basic-drawing-in-wpf-overview?branch=pr-en-us-1855&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->