### PR TITLE
Restrict auto-merge label power

### DIFF
--- a/.github/policies/auto-merge.yml
+++ b/.github/policies/auto-merge.yml
@@ -8,37 +8,41 @@ where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
-    - description: Approve and auto-squash-merge PRs to main labeled with 'auto-merge'
+    - description: Approve and auto-squash-merge bot PRs to main labeled 'auto-merge'
       triggerOnOwnActions: true
       if:
-      - payloadType: Pull_Request
-      - labelAdded:
-          label: ':octocat: auto-merge'
-      - targetsBranch:
-          branch: main
+        - payloadType: Pull_Request
+        - labelAdded:
+            label: ':octocat: auto-merge'
+        - targetsBranch:
+            branch: main
+        - or:
+            - isActivitySender:
+                user: dotnet-policy-service[bot]
       then:
-      - enableAutoMerge:
-          mergeMethod: Squash
-      - approvePullRequest:
-          comment: "Approved; this PR will merge when all status checks pass."
+        - enableAutoMerge:
+            mergeMethod: Squash
+        - approvePullRequest:
+            comment: "Approved; this PR will merge when all status checks pass."
 
-    - description: Auto-merge PRs to live labeled with 'auto-merge'
+    - description: Auto-merge policy service bot PRs to live labeled 'auto-merge'
       triggerOnOwnActions: true
       if:
-      - payloadType: Pull_Request
-      - labelAdded:
-          label: ':octocat: auto-merge'
-      - targetsBranch:
-          branch: live
+        - payloadType: Pull_Request
+        - labelAdded:
+            label: ':octocat: auto-merge'
+        - targetsBranch:
+            branch: live
+        - isActivitySender:
+            user: dotnet-policy-service[bot]
       then:
-      - enableAutoMerge:
-          mergeMethod: Merge
+        - enableAutoMerge:
+            mergeMethod: Merge
 
     - description: Don't auto-merge PRs with 'auto-merge' label removed
       if:
-      - payloadType: Pull_Request
-      - labelRemoved:
-          label: ':octocat: auto-merge'
+        - payloadType: Pull_Request
+        - labelRemoved:
+            label: ':octocat: auto-merge'
       then:
-      - disableAutoMerge
-
+        - disableAutoMerge


### PR DESCRIPTION
Restrict auto-merge to PRs whose 'auto-merge' label was added by the dotnet policy service bot.