### PR TITLE
Fix binding validation path

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation.md
+++ b/dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation.md
@@ -19,20 +19,29 @@ This example shows how to use an <xref:System.Windows.Controls.Validation.ErrorT
 
 The text content of the <xref:System.Windows.Controls.TextBox> in the following example is bound to the `Age` property (of type int) of a binding source object named `ods`. The binding is set up to use a validation rule named `AgeRangeRule` so that if the user enters non-numeric characters or a value that is smaller than 21 or greater than 130, a red exclamation mark appears next to the text box and a tool tip with the error message appears when the user moves the mouse over the text box.
 
-[!code-xaml[BindValidation#2](~/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml#2)]
+[!code-xaml[BindValidation#2](../../../samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml#2)]
 
 The following example shows the implementation of `AgeRangeRule`, which inherits from <xref:System.Windows.Controls.ValidationRule> and overrides the <xref:System.Windows.Controls.ValidationRule.Validate%2A> method. The `Int32.Parse` method is called on the value to make sure that it does not contain any invalid characters. The <xref:System.Windows.Controls.ValidationRule.Validate%2A> method returns a <xref:System.Windows.Controls.ValidationResult> that indicates if the value is valid based on whether an exception is caught during the parsing and whether the age value is outside of the lower and upper bounds.
 
-[!code-csharp[BindValidation#3](~/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/AgeRangeRule.cs#3)]
-[!code-vb[BindValidation#3](~/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/AgeRangeRule.vb#3)]
+[!code-csharp[BindValidation#3](../../../samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/AgeRangeRule.cs#3)]
+[!code-vb[BindValidation#3](../../../samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/AgeRangeRule.vb#3)]
 
 The following example shows the custom <xref:System.Windows.Controls.ControlTemplate> `validationTemplate` that creates a red exclamation mark to notify the user of a validation error. Control templates are used to redefine the appearance of a control.
 
-[!code-xaml[BindValidation#4](~/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml#4)]
+[!code-xaml[BindValidation#4](../../../samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml#4)]
 
 As shown in the following example, the <xref:System.Windows.Controls.ToolTip> that shows the error message is created using the style named `textBoxInError`. If the value of <xref:System.Windows.Controls.Validation.HasError%2A> is `true`, the trigger sets the tool tip of the current <xref:System.Windows.Controls.TextBox> to its first validation error. The <xref:System.Windows.Data.Binding.RelativeSource%2A> is set to <xref:System.Windows.Data.RelativeSourceMode.Self>, referring to the current element.
 
-[!code-xaml[BindValidation#5](~/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml#5)]
+[!code-xaml[BindValidation#5](../../../samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml#5)]
+
+## Data object
+
+The following snippet is the data object used in the previous code examples. An instance is created in the XAML as a static resource with the name of `ods`:
+
+:::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/MyDataSource.cs" id="DataSource":::
+:::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/MyDataSource.vb" id="DataSource":::
+
+## Complete example
 
 For the complete example, see [Bind Validation sample](https://github.com/Microsoft/WPF-Samples/tree/master/Data%20Binding/BindValidation).
   

--- a/dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation.md
+++ b/dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation.md
@@ -36,7 +36,7 @@ As shown in the following example, the <xref:System.Windows.Controls.ToolTip> th
 
 ## Data object
 
-The following snippet is the data object used in the previous code examples. An instance is created in the XAML as a static resource with the name of `ods`:
+The following snippet is the data object used in the previous code examples. An instance is created in the XAML as a static resource with the key of `ods`:
 
 :::code language="csharp" source="../../../samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/MyDataSource.cs" id="DataSource":::
 :::code language="vb" source="../../../samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/MyDataSource.vb" id="DataSource":::

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/AgeRangeRule.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/AgeRangeRule.cs
@@ -12,10 +12,6 @@ namespace SDKSample
         public int Min { get; set; }
         public int Max { get; set; }
 
-        public AgeRangeRule()
-        {
-        }
-
         public override ValidationResult Validate(object value, CultureInfo cultureInfo)
         {
             int age = 0;
@@ -23,7 +19,7 @@ namespace SDKSample
             try
             {
                 if (((string)value).Length > 0)
-                    age = Int32.Parse((String)value);
+                    age = int.Parse((String)value);
             }
             catch (Exception e)
             {

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/BindingValidation.csproj
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/BindingValidation.csproj
@@ -1,4 +1,4 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <!-- MSBUILD Project File -->
   <PropertyGroup>
     <BuildSystem>MSBuild</BuildSystem>
@@ -12,9 +12,10 @@
     <ProductVersion>10.0.20821</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{950D18C5-F942-494B-87F5-DE051442ABF6}</ProjectGuid>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,12 +23,14 @@
     <Optimize>false</Optimize>
     <OutputPath>.\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
     <Optimize>true</Optimize>
     <OutputPath>.\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
@@ -69,5 +72,8 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
 </Project>

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/MyDataSource.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/MyDataSource.cs
@@ -2,33 +2,18 @@
 
 namespace SDKSample
 {
+    //<DataSource>
     public class MyDataSource
     {
-        private int _age;
-        private int _age2;
-        private int _age3;
-
         public MyDataSource()
         {
             Age = 0;
             Age2 = 0;
         }
 
-        public int Age
-        {
-            get { return _age; }
-            set { _age = value; }
-        }
-        public int Age2
-        {
-            get { return _age2; }
-            set { _age2 = value; }
-        }
-
-        public int Age3
-        {
-            get { return _age3; }
-            set { _age3 = value; }
-        }
+        public int Age { get; set; }
+        public int Age2 { get; set; }
+        public int Age3 { get; set; }
     }
+    //</DataSource>
 }

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/Window1.xaml
@@ -1,7 +1,7 @@
 ﻿<Window
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:c="clr-namespace:SDKSample"
+  xmlns:local="clr-namespace:SDKSample"
   x:Class="SDKSample.Window1"
   Title="Binding Validation Sample"
   SizeToContent="WidthAndHeight"
@@ -9,7 +9,7 @@
 
   <!--<Snippet1>-->
     <Window.Resources>
-      <c:MyDataSource x:Key="ods"/>
+      <local:MyDataSource x:Key="ods"/>
 
       <!--<Snippet4>-->
       <ControlTemplate x:Key="validationTemplate">
@@ -25,8 +25,8 @@
         <Style.Triggers>
           <Trigger Property="Validation.HasError" Value="true">
             <Setter Property="ToolTip"
-              Value="{Binding RelativeSource={x:Static RelativeSource.Self},
-                              Path=(Validation.Errors)/ErrorContent}"/>
+                    Value="{Binding RelativeSource={x:Static RelativeSource.Self},
+                                    Path=(Validation.Errors)[0].ErrorContent}"/>
           </Trigger>
         </Style.Triggers>
       </Style>
@@ -65,7 +65,7 @@
         <Binding Path="Age" Source="{StaticResource ods}"
                  UpdateSourceTrigger="PropertyChanged" >
           <Binding.ValidationRules>
-            <c:AgeRangeRule Min="21" Max="130"/>
+            <local:AgeRangeRule Min="21" Max="130"/>
           </Binding.ValidationRules>
         </Binding>
       </TextBox.Text>
@@ -81,7 +81,7 @@
         <Binding Path="Age2" Source="{StaticResource ods}"
                  UpdateSourceTrigger="PropertyChanged" >
           <Binding.ValidationRules>
-            <c:AgeRangeRule Min="21" Max="130"/>
+            <local:AgeRangeRule Min="21" Max="130"/>
           </Binding.ValidationRules>
         </Binding>
       </TextBox.Text>

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/app.config
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/BindValidation/CSharp/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/BindValidation_VB.vbproj
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/BindValidation_VB.vbproj
@@ -1,4 +1,4 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -21,8 +21,9 @@
     <IsWebBootstrapper>true</IsWebBootstrapper>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <PublishUrl>Publish\</PublishUrl>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <ProductVersion>10.0.20821</ProductVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,6 +35,7 @@
     <OutputPath>bin\</OutputPath>
     <DocumentationFile>BindValidation_VB.xml</DocumentationFile>
     <NoWarn>42016,42017,42018,42019,42032,42314</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>
@@ -44,6 +46,7 @@
     <OutputPath>bin\</OutputPath>
     <DocumentationFile>BindValidation_VB.xml</DocumentationFile>
     <NoWarn>42016,42017,42018,42019,42032,42314</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -109,6 +112,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="My Project\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
 </Project>

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/MyDataSource.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/MyDataSource.vb
@@ -1,43 +1,12 @@
-﻿    Public Class MyDataSource
-        ' Methods
-        Public Sub New()
-            Me.Age = 0
-            Me.Age2 = 0
-        End Sub
+﻿'<DataSource>
+Public Class MyDataSource
+    Public Sub New()
+        Me.Age = 0
+        Me.Age2 = 0
+    End Sub
 
-
-        ' Properties
-        Public Property Age As Integer
-            Get
-                Return Me._age
-            End Get
-            Set(ByVal value As Integer)
-                Me._age = value
-            End Set
-        End Property
-
-        Public Property Age2 As Integer
-            Get
-                Return Me._age2
-            End Get
-            Set(ByVal value As Integer)
-                Me._age2 = value
-            End Set
-        End Property
-
-        Public Property Age3 As Integer
-            Get
-                Return Me._age3
-            End Get
-            Set(ByVal value As Integer)
-                Me._age3 = value
-            End Set
-        End Property
-
-
-        ' Fields
-        Private _age As Integer
-        Private _age2 As Integer
-        Private _age3 As Integer
-    End Class
-
+    Public Property Age As Integer
+    Public Property Age2 As Integer
+    Public Property Age3 As Integer
+End Class
+'</DataSource>

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/Window1.xaml
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/Window1.xaml
@@ -1,14 +1,14 @@
 ﻿<Window
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-  xmlns:c="clr-namespace:BindValidation_VB"
+  xmlns:local="clr-namespace:BindValidation_VB"
   x:Class="Window1"
   Title="Binding Validation Sample"
   SizeToContent="WidthAndHeight"
   ResizeMode="NoResize">
 
     <Window.Resources>
-      <c:MyDataSource x:Key="ods"/>
+      <local:MyDataSource x:Key="ods"/>
 
       <ControlTemplate x:Key="validationTemplate">
         <DockPanel>
@@ -57,7 +57,7 @@
         <Binding Path="Age" Source="{StaticResource ods}"
                  UpdateSourceTrigger="PropertyChanged" >
           <Binding.ValidationRules>
-            <c:AgeRangeRule Min="21" Max="130"/>
+            <local:AgeRangeRule Min="21" Max="130"/>
           </Binding.ValidationRules>
         </Binding>
       </TextBox.Text>
@@ -71,7 +71,7 @@
         <Binding Path="Age2" Source="{StaticResource ods}"
                  UpdateSourceTrigger="PropertyChanged" >
           <Binding.ValidationRules>
-            <c:AgeRangeRule Min="21" Max="130"/>
+            <local:AgeRangeRule Min="21" Max="130"/>
           </Binding.ValidationRules>
         </Binding>
       </TextBox.Text>

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/app.config
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/BindValidation/VisualBasic/app.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+    <system.diagnostics>
+        <sources>
+            <!-- This section defines the logging configuration for My.Application.Log -->
+            <source name="DefaultSource" switchName="DefaultSwitch">
+                <listeners>
+                    <add name="FileLog"/>
+                    <!-- Uncomment the below section to write to the Application Event Log -->
+                    <!--<add name="EventLog"/>-->
+                </listeners>
+            </source>
+        </sources>
+        <switches>
+            <add name="DefaultSwitch" value="Information"/>
+        </switches>
+        <sharedListeners>
+            <add name="FileLog" type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" initializeData="FileLogWriter"/>
+            <!-- Uncomment the below section and replace APPLICATION_NAME with the name of your application to write to the Application Event Log -->
+            <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
+        </sharedListeners>
+    </system.diagnostics>
+
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
## Summary

- Adjust binding path style for the tooltip.
- VS auto upgraded projects to .NET 4.8.
- Trimmed the data object.
- Added the data object to the article.

Fixes #1878 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation.md](https://github.com/dotnet/docs-desktop/blob/4f43925dd2ea3918b9ba2926f834fac720262148/dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation.md) | [dotnet-desktop-guide/framework/wpf/data/how-to-implement-binding-validation](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-implement-binding-validation?branch=pr-en-us-1916&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->