### PR TITLE
Remove empty sections in WPF articles

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/drag-and-drop.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/drag-and-drop.md
@@ -29,5 +29,3 @@ Windows Presentation Foundation (WPF) provides a highly flexible drag and drop i
   <xref:System.Windows.DragDropEffects>  
   <xref:System.Windows.DragEventHandler>  
   <xref:System.Windows.TextDataFormat>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/advanced/element-tree-and-serialization-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/element-tree-and-serialization-how-to-topics.md
@@ -25,5 +25,3 @@ The topics in this section describe how to use the WPF element tree.
  <xref:System.Windows.Media.VisualTreeHelper>  
   
  <xref:System.Windows.Markup>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/advanced/events-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/events-how-to-topics.md
@@ -27,5 +27,3 @@ The topics in this section describe how to use events in WPF.
  <xref:System.Windows.EventManager>  
   
  <xref:System.Windows.RoutingStrategy>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/advanced/globalization-and-localization.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/globalization-and-localization.md
@@ -35,5 +35,3 @@ Windows Presentation Foundation (WPF) provides extensive support for the develop
  <xref:System.Resources.NeutralResourcesLanguageAttribute>  
   
  [xml:lang Handling in XAML](/dotnet/desktop/xaml-services/xml-language-handling)  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/advanced/input-and-commands-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/input-and-commands-how-to-topics.md
@@ -42,5 +42,3 @@ The topics in this section describe how to use the input and commanding infrastr
  <xref:System.Windows.Input.Mouse>  
   
  <xref:System.Windows.Input.FocusManager>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/advanced/migration-and-interoperability.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/migration-and-interoperability.md
@@ -35,5 +35,3 @@ This page contains links to documents that discuss how to implement interoperati
 | <xref:System.Windows.Interop.HwndSource>                 | Hosts a WPF region within a Win32 application.                                                                                                                                                                                                                                                                                |
 | <xref:System.Windows.Interop.HwndHost>                   | Base class for <xref:System.Windows.Forms.Integration.WindowsFormsHost>, defines some basic functionality that all HWND-based technologies use when hosted by a WPF application. Subclass this to host a Win32 window within a WPF application. |
 | <xref:System.Windows.Interop.BrowserInteropHelper>       | A helper class for reporting conditions of the browser environment for a WPF application that is hosted by a browser.                                                                                                                                                                                                         |
-
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/adorners-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/adorners-how-to-topics.md
@@ -31,5 +31,3 @@ The following examples demonstrate how to accomplish common tasks using the Wind
  <xref:System.Windows.Media.AdornerHitTestResult>  
   
  <xref:System.Windows.Documents.AdornerLayer>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/adorners.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/adorners.md
@@ -28,5 +28,3 @@ This section provides information about Adorners and the Windows Presentation Fo
  <xref:System.Windows.Media.AdornerHitTestResult>  
   
  <xref:System.Windows.Documents.AdornerLayer>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/checkbox.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/checkbox.md
@@ -24,5 +24,3 @@ CheckBox controls in different states
   <xref:System.Windows.Controls.RadioButton>  
   <xref:System.Windows.Controls.Primitives.ButtonBase>  
   <xref:System.Windows.Controls.Primitives.RepeatButton>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/contextmenu.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/contextmenu.md
@@ -26,5 +26,3 @@ ContextMenu in different states
 ## Reference  
 
  <xref:System.Windows.Controls.ContextMenu>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/expander.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/expander.md
@@ -28,5 +28,3 @@ An <xref:System.Windows.Controls.Expander> allows a user to view a header and ex
 ## Reference  
 
  <xref:System.Windows.Controls.Expander>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/gridsplitter-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/gridsplitter-how-to-topics.md
@@ -24,5 +24,3 @@ The topics in this section describe how to use the <xref:System.Windows.Controls
  <xref:System.Windows.Controls.GridSplitter>  
   
  <xref:System.Windows.Controls.Grid>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/gridsplitter.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/gridsplitter.md
@@ -21,5 +21,3 @@ The <xref:System.Windows.Controls.GridSplitter> redistributes space between colu
 ## Reference  
 
  <xref:System.Windows.Controls.GridSplitter>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/groupbox.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/groupbox.md
@@ -24,5 +24,3 @@ The <xref:System.Windows.Controls.GroupBox> control is a <xref:System.Windows.Co
 ## Reference  
 
  <xref:System.Windows.Controls.GroupBox>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/listbox-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/listbox-how-to-topics.md
@@ -25,5 +25,3 @@ The topics in this section describe how to use the <xref:System.Windows.Controls
  <xref:System.Windows.Controls.ListBox>  
   
  <xref:System.Windows.Controls.ListBoxItem>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/listbox.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/listbox.md
@@ -26,5 +26,3 @@ Typical ListBox
 
  <xref:System.Windows.Controls.ListBox>  
   <xref:System.Windows.Controls.ListBoxItem>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/menu.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/menu.md
@@ -28,5 +28,3 @@ Menus in different states
   <xref:System.Windows.Controls.MenuItem>  
   <xref:System.Windows.Controls.Primitives.MenuBase>  
   <xref:System.Windows.Controls.ContextMenu>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/popup.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/popup.md
@@ -28,5 +28,3 @@ The <xref:System.Windows.Controls.Primitives.Popup> control displays content in 
 ## Reference  
 
  <xref:System.Windows.Controls.Primitives.Popup>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/progressbar.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/progressbar.md
@@ -23,5 +23,3 @@ A <xref:System.Windows.Controls.ProgressBar> indicates the progress of an operat
 
  <xref:System.Windows.Controls.ProgressBar>  
   <xref:System.Windows.Controls.Primitives.StatusBar>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/radiobutton.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/radiobutton.md
@@ -21,5 +21,3 @@ Typical RadioButton
 ## Reference  
 
  <xref:System.Windows.Controls.Primitives.ToggleButton>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/repeatbutton.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/repeatbutton.md
@@ -23,5 +23,3 @@ Typical RepeatButton
 ## Reference  
 
  <xref:System.Windows.Controls.Primitives.RepeatButton>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/statusbar.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/statusbar.md
@@ -23,5 +23,3 @@ A <xref:System.Windows.Controls.Primitives.StatusBar> is a horizontal area at th
 
  <xref:System.Windows.Controls.Primitives.StatusBar>  
   <xref:System.Windows.Controls.Primitives.StatusBarItem>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/tabcontrol.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/tabcontrol.md
@@ -22,5 +22,3 @@ Typical TabControl
 
  <xref:System.Windows.Controls.TabControl>  
   <xref:System.Windows.Controls.TabItem>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/toolbar.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/toolbar.md
@@ -30,5 +30,3 @@ Vertical Toolbar
 
  <xref:System.Windows.Controls.ToolBar>  
   <xref:System.Windows.Controls.ToolBarTray>  
-  
-## Related Sections

--- a/dotnet-desktop-guide/framework/wpf/controls/treeview-how-to-topics.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/treeview-how-to-topics.md
@@ -26,5 +26,3 @@ The topics in this section describe how to use the <xref:System.Windows.Controls
  <xref:System.Windows.Controls.TreeView>  
   
  <xref:System.Windows.Controls.TreeViewItem>  
-  
-## Related Sections


### PR DESCRIPTION
## Summary

Some of the WPF control reference had a bunch of empty sections at the end of the articles.

@BillWagner 

Fixes #1877