### PR TITLE
Update startup time guidance to not recommend BinaryFormatter

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/advanced/application-startup-time.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/application-startup-time.md
@@ -118,7 +118,7 @@ The amount of time that is required for a WPF application to start can vary grea
   
 ## Use XML Serializer Generator
 
- If you use the <xref:System.Xml.Serialization.XmlSerializer> class, you can achieve better performance if you pre-generate the serialization assembly using the [XML Serializer Generator tool (Sgen.exe)](/dotnet/standard/serialization/xml-serializer-generator-tool-sgen-exe).
+ If you use the <xref:System.Xml.Serialization.XmlSerializer> class, you can achieve better performance if you pregenerate the serialization assembly using the [XML Serializer Generator tool (Sgen.exe)](/dotnet/standard/serialization/xml-serializer-generator-tool-sgen-exe).
   
 ## Configure ClickOnce to Check for Updates After Startup  
 

--- a/dotnet-desktop-guide/framework/wpf/advanced/application-startup-time.md
+++ b/dotnet-desktop-guide/framework/wpf/advanced/application-startup-time.md
@@ -116,11 +116,9 @@ The amount of time that is required for a WPF application to start can vary grea
 
  Use the <xref:System.Resources.NeutralResourcesLanguageAttribute> to specify the neutral culture for the <xref:System.Resources.ResourceManager>. This approach avoids unsuccessful assembly lookups.  
   
-## Use the BinaryFormatter Class for Serialization  
+## Use XML Serializer Generator
 
- If you must use serialization, use the <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> class instead of the <xref:System.Xml.Serialization.XmlSerializer> class. The <xref:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter> class is implemented in the Base Class Library (BCL) in the mscorlib.dll assembly. The <xref:System.Xml.Serialization.XmlSerializer> is implemented in the System.Xml.dll assembly, which might be an additional DLL to load.  
-  
- If you must use the <xref:System.Xml.Serialization.XmlSerializer> class, you can achieve better performance if you pre-generate the serialization assembly.  
+ If you use the <xref:System.Xml.Serialization.XmlSerializer> class, you can achieve better performance if you pre-generate the serialization assembly using the [XML Serializer Generator tool (Sgen.exe)](/dotnet/standard/serialization/xml-serializer-generator-tool-sgen-exe).
   
 ## Configure ClickOnce to Check for Updates After Startup  
 


### PR DESCRIPTION
## Summary

Update the Startup Time guidance to not recommend using BinaryFormatter. Instead, recommend using the XML Serializer Generator tool (Sgen.exe) for better performance.

I searched through this repo and the only other references I saw to BinaryFormatter are resource files from the samples that indicate data was serialized using BinaryFormatter into the resources. That's probably OK to keep.

Fixes #1551 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/advanced/application-startup-time.md](https://github.com/dotnet/docs-desktop/blob/eb9ca63bff507ecc5d9e54ccc75fcbd97c1f7d76/dotnet-desktop-guide/framework/wpf/advanced/application-startup-time.md) | [dotnet-desktop-guide/framework/wpf/advanced/application-startup-time](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/application-startup-time?branch=pr-en-us-1924&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->