### PR TITLE
Policy

### DIFF
--- a/.github/policies/close-issues.yml
+++ b/.github/policies/close-issues.yml
@@ -1,5 +1,5 @@
-name: Stale issues
-description: Close needs-more-info issues that haven't had a response in 14 days
+name: Close issues
+description: Close issues based on label
 resource: repository
 where:
 configuration:
@@ -18,4 +18,27 @@ configuration:
             actions:
               - addReply:
                   reply: This issue has been automatically closed due to no response from the original author. Feel free to reopen it if you have more information that can help us investigate the issue further.
+              - closeIssue
+
+        eventResponderTasks:
+          - description: Remove needs-more-info label when author comments on issue
+            if:
+              - payloadType: Issue_Comment
+              - isAction:
+                  action: Created
+              - isActivitySender:
+                  issueAuthor: True
+              - hasLabel:
+                  label: needs-more-info
+              - isOpen
+            then:
+              - removeLabel:
+                  label: needs-more-info
+              
+          - description: Close issues labeled 'code-of-conduct'
+            if:
+              - payloadType: Issues
+              - hasLabel:
+                  label: code-of-conduct
+            then:
               - closeIssue

--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -24,6 +24,20 @@ configuration:
                         label: okr-quality
 
         eventResponderTasks:
+            - description: Label dependabot issues
+              if:
+                - payloadType: Issues
+                - isAction: 
+                    action: Opened
+                - or:
+                  - isActivitySender:
+                      user: dependabot
+                  - isActivitySender:
+                      user: dependabot[bot]
+              then:
+                - addLabel:
+                   label: dependencies
+
             - description: Add in-pr label to issues
               if:
                   - payloadType: Pull_Request

--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -62,6 +62,18 @@ configuration:
                 - removeLabel:
                    label: 'in-progress'
 
+            - description: Issue closed by author, add "resolved-by-customer" label
+              if:
+                - payloadType: Issues
+                - isAction: 
+                    action: Closed
+                - isActivitySender:
+                    user: ${issueAuthor}
+
+              then:
+                - addLabel:
+                   label: resolved-by-customer
+
             - description: Add in-pr label to issues
               if:
                   - payloadType: Pull_Request

--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -1,6 +1,6 @@
-id:
-name: GitOps.PullRequestIssueManagement
-description: GitOps.PullRequestIssueManagement primitive
+id: label.issues
+name: GitOps.IssueManagement
+description: Management logic around issues
 owner:
 resource: repository
 disabled: false
@@ -37,6 +37,19 @@ configuration:
               then:
                 - addLabel:
                    label: dependencies
+
+        eventResponderTasks:
+            - description: Reopen issue so remove "won't fix" label
+              if:
+                - payloadType: Issues
+                - isAction: 
+                    action: Reopened
+                - hasLabel:
+                    label: "won't fix"
+                  
+              then:
+                - removeLabel:
+                   label: "won't fix"
 
             - description: Add in-pr label to issues
               if:

--- a/.github/policies/label-issues.yml
+++ b/.github/policies/label-issues.yml
@@ -38,7 +38,6 @@ configuration:
                 - addLabel:
                    label: dependencies
 
-        eventResponderTasks:
             - description: Reopen issue so remove "won't fix" label
               if:
                 - payloadType: Issues
@@ -50,6 +49,18 @@ configuration:
               then:
                 - removeLabel:
                    label: "won't fix"
+
+            - description: Remove "in-progress" label when issue closed
+              if:
+                - payloadType: Issues
+                - isAction: 
+                    action: Closed
+                - hasLabel:
+                    label: 'in-progress'
+                  
+              then:
+                - removeLabel:
+                   label: 'in-progress'
 
             - description: Add in-pr label to issues
               if:

--- a/.repoman.yml
+++ b/.repoman.yml
@@ -43,9 +43,6 @@ issues:
 
   closed:
 
-    # Issue closed, remove in-progress and not triaged labels
-    - labels-remove: ["in-progress"]
-
     # Check if the issue was closed by the user who opened it
     - check:
         - type: query

--- a/.repoman.yml
+++ b/.repoman.yml
@@ -14,23 +14,6 @@ config:
 
 issues:
 
-  unlabeled: "labeled"
-  
-  labeled:
-
-    # Checks for binary/source incompatible checkboxes and adds a label
-    - check:
-        - type: query
-          value: "contains(InstanceData.IssuePrBody, '- [x] **Binary incompatible**') == `true` || contains(InstanceData.IssuePrBody, '- [X] **Binary incompatible**') == `true`"
-      pass:
-        - labels-add: ["binary incompatible"]
-
-    - check:
-        - type: query
-          value: "contains(InstanceData.IssuePrBody, '- [x] **Source incompatible**') == `true` || contains(InstanceData.IssuePrBody, '- [X] **Source incompatible**') == `true`"
-      pass:
-        - labels-add: ["source incompatible"]
-
   opened:
 
     # Add links to related issues if it's a doc issue
@@ -84,16 +67,3 @@ projects_v2_item:
           value: "EventPayload.changes.field_value.field_name == 'Priority' || EventPayload.changes.field_value.field_name == 'Size'"
       pass:
         - labels-add: [":world_map: mapQUEST"]
-
-issue_comment:
-
-  created:
-
-    # someone creates a comment with #please-review in it, add changes-addressed label
-    - check:
-        - type: query
-          value: "Issue.State.StringValue == 'open' && Issue.User.Id == Comment.User.Id"
-        - type: comment-body
-          value: ^#please-review$
-      pass:
-        - labels-add: ["changes-addressed"]

--- a/.repoman.yml
+++ b/.repoman.yml
@@ -41,15 +41,6 @@ issues:
       pass:
         - link-related-issues
 
-  closed:
-
-    # Check if the issue was closed by the user who opened it
-    - check:
-        - type: query
-          value: "Issue.User.Id == EventPayload.sender.id"
-      pass:
-        - labels-add: ["resolved-by-customer"]
-
 pull_request:
 
   reopened: opened

--- a/.repoman.yml
+++ b/.repoman.yml
@@ -33,13 +33,6 @@ issues:
 
   opened:
 
-    # Dependabot opened issue, label it
-    - check:
-        - type: query
-          value: "Issue.User.Login == 'dependabot'"
-      pass:
-        - labels-add: ["dependencies"]
-
     # Add links to related issues if it's a doc issue
     - check:
         - type: metadata-exists

--- a/.repoman.yml
+++ b/.repoman.yml
@@ -41,11 +41,6 @@ issues:
       pass:
         - link-related-issues
 
-  reopened:
-
-    # Remove won't fix label
-    - labels-remove: ["won't fix"]
-
   closed:
 
     # Issue closed, remove in-progress and not triaged labels


### PR DESCRIPTION
## Summary

- Bring the close-issues up to date with what's in Docs repo.
- Migrate basic logic items from repoman
  - Issue opened by dependabot: add **dependencies** label.
  - Issue reopened and has **won't fix** label, remove it.
  - Issue closed, remove **in-progress** label.
  - Issue closed by the customer, add **resolved-by-customer** label.
