### PR TITLE
Fix description discrepancy.

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/how-to-access-keyed-collections-in-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/how-to-access-keyed-collections-in-windows-forms.md
@@ -1,6 +1,6 @@
 ---
 title: "How to: Access Keyed Collections"
-descriptions: Learn how to access keyed collections, a functionality that has been added to many collection classes that are typically used by Windows Forms applications.
+description: Learn to Access Keyed Collections in Windows Forms with .NET Framework 4.8 - ListView, Control, TabControl, and more. Boost your app's functionality.
 ms.date: "03/30/2017"
 dev_langs: 
   - "csharp"
@@ -9,7 +9,6 @@ helpviewer_keywords:
   - "keyed collections [Windows Forms]"
   - "collections [Windows Forms], accessing with keys"
 ms.assetid: b9b79b8b-d9bf-4f8c-b9d6-9578bc3219d3
-description: Learn to Access Keyed Collections in Windows Forms with .NET Framework 4.8 - ListView, Control, TabControl, and more. Boost your app's functionality.
 ---
 # How to: Access Keyed Collections in Windows Forms
 


### PR DESCRIPTION
Moved the real description field up and replaced the descriptions field.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/how-to-access-keyed-collections-in-windows-forms.md](https://github.com/dotnet/docs-desktop/blob/e5bc0d213426a9160b36954205fa14ccfc57c3dd/dotnet-desktop-guide/framework/winforms/how-to-access-keyed-collections-in-windows-forms.md) | [dotnet-desktop-guide/framework/winforms/how-to-access-keyed-collections-in-windows-forms](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/how-to-access-keyed-collections-in-windows-forms?branch=pr-en-us-1964&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->