### PR TITLE
Corrected grammatical mistake

### DIFF
--- a/dotnet-desktop-guide/net/wpf/windows/index.md
+++ b/dotnet-desktop-guide/net/wpf/windows/index.md
@@ -181,7 +181,7 @@ How you implement your window determines how it's configured for MSBuild. For a 
 - XAML markup files are configured as MSBuild `Page` items.
 - Code-behind files are configured as MSBuild `Compile` items.
 
-.NET SDK projects automatically import the correct `Page` and `Compile` items for you and you don't need to do declare these. When the project is configured for WPF, the XAML markup files are automatically imported as `Page` items, and the corresponding code-behind file is imported as `Compile`.
+.NET SDK projects automatically import the correct `Page` and `Compile` items for you, and you don't need to declare these. When the project is configured for WPF, the XAML markup files are automatically imported as `Page` items, and the corresponding code-behind file is imported as `Compile`.
 
 MSBuild projects won't automatically import the types and you must declare them yourself:
 


### PR DESCRIPTION
## Summary

Corrected grammatical mistake in WPF doc.

Fixes #1965  


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/windows/index.md](https://github.com/dotnet/docs-desktop/blob/1e6e320f6b4d395fe33860c6fa04cc7b0906b559/dotnet-desktop-guide/net/wpf/windows/index.md) | [dotnet-desktop-guide/net/wpf/windows/index](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/windows/index?branch=pr-en-us-1966&view=netdesktop-9.0) |

<!-- PREVIEW-TABLE-END -->