### PR TITLE
Fix the typo on the height and width of the window

### DIFF
--- a/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md
+++ b/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md
@@ -288,7 +288,7 @@ For our example app, this window is too large, and the title bar isn't descripti
     :::image type="content" source="media/create-app-visual-studio/app-default.png" alt-text="A blank WPF app" :::
 
 01. Change the title of the window by setting the `Title` to `Names`.
-01. Change the size of the window by setting the `Width` to `180` and `Height` to `260`.
+01. Change the size of the window by setting the `Height` to `180` and `Width` to `260`.
 
     :::code language="xaml" source="snippets/create-app-visual-studio/csharp/Start.xaml" highlight="8":::
 


### PR DESCRIPTION
## Summary

Fix the Typo on Height and Width

Fixes #1976 


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md](https://github.com/dotnet/docs-desktop/blob/3fef634ef97047965626b0ad8da2262cc0c9bd50/dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio.md) | [dotnet-desktop-guide/net/wpf/get-started/create-app-visual-studio](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/get-started/create-app-visual-studio?branch=pr-en-us-1977&view=netdesktop-9.0) |

<!-- PREVIEW-TABLE-END -->