### PR TITLE
UUF: Empty section in wpf separator article

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/controls/separator.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/separator.md
@@ -11,9 +11,7 @@ ms.assetid: 1b872bc6-1a26-401c-989b-3fafecc5a4ef
 ---
 # Separator
 
-A <xref:System.Windows.Controls.Separator> control draws a line, horizontal or vertical, between items in controls, such as <xref:System.Windows.Controls.ListBox>, <xref:System.Windows.Controls.Menu>, and <xref:System.Windows.Controls.ToolBar>.  
-  
-## In This Section  
+A <xref:System.Windows.Controls.Separator> control draws a line, horizontal or vertical, between items in controls, such as <xref:System.Windows.Controls.ListBox>, <xref:System.Windows.Controls.Menu>, and <xref:System.Windows.Controls.ToolBar>.
   
 ## Reference  
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/controls/separator.md](https://github.com/dotnet/docs-desktop/blob/47b20b8cb910e27082ce8b9d78f38d76d43e9f58/dotnet-desktop-guide/framework/wpf/controls/separator.md) | [dotnet-desktop-guide/framework/wpf/controls/separator](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/separator?branch=pr-en-us-1986&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->