### PR TITLE
Update design-time-errors-in-the-windows-forms-designer.md

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer.md
@@ -36,7 +36,7 @@ If a help topic for the error is available, click the **MSDN Help** link to navi
 
 ## Forum posts about this error
 
-Select the **Search the MSDN Forums for posts related to this error** link to navigate to the old Microsoft Developer Network forums. You might want to search or ask a question on the [Microsoft Q&A](/answers/tags/21/windows-forms) or [StackOverflow](https://stackoverflow.com/questions/tagged/winforms) forums.
+Select the **Search the MSDN Forums for posts related to this error** link to navigate to the old Microsoft Developer Network forums. You might also want to search or ask a question on the [Microsoft Q&A](/answers/tags/21/windows-forms) or [StackOverflow](https://stackoverflow.com/questions/tagged/winforms) forums.
 
 ## Design-time errors
 

--- a/dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer.md
@@ -36,7 +36,7 @@ If a help topic for the error is available, click the **MSDN Help** link to navi
 
 ## Forum posts about this error
 
-Click the **Search the MSDN Forums for posts related to this error** link to navigate to the Microsoft Developer Network forums. You may want to specifically search the [Windows Forms Designer](https://social.msdn.microsoft.com/Forums/windows/home?forum=winformsdesigner) or [Windows Forms](https://social.msdn.microsoft.com/Forums/windows/home?category=windowsforms) forums.
+Select the **Search the MSDN Forums for posts related to this error** link to navigate to the old Microsoft Developer Network forums. You might want to search or ask a question on the [Microsoft Q&A](/answers/tags/21/windows-forms) or [StackOverflow](https://stackoverflow.com/questions/tagged/winforms) forums.
 
 ## Design-time errors
 


### PR DESCRIPTION
## Summary

Change the links/wording to match the .NET 9 version.

Fixes #161

@gewarren 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer.md](https://github.com/dotnet/docs-desktop/blob/2c2893cc92e48e4b55d32ba61f811eded28200ab/dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer.md) | [dotnet-desktop-guide/framework/winforms/controls/design-time-errors-in-the-windows-forms-designer](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/design-time-errors-in-the-windows-forms-designer?branch=pr-en-us-2001&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->