### PR TITLE
Add what's new .NET 10 Preview 1

### DIFF
--- a/.openpublishing.redirection.winforms.json
+++ b/.openpublishing.redirection.winforms.json
@@ -493,10 +493,6 @@
             "redirect_url": "/dotnet/desktop/winforms/multiple-controls-bound-to-data-source-synchronized?view=netframeworkdesktop-4.8"
         },
         {
-            "source_path": "dotnet-desktop-guide/net/winforms/whats-new/index.md",
-            "redirect_url": "/dotnet/desktop/winforms/whats-new/net90?view=netdesktop-9.0"
-        },
-        {
             "source_path": "dotnet-desktop-guide/net/winforms/controls-design/index.md",
             "redirect_url": "/dotnet/desktop/winforms/controls-design/overview?view=netdesktop-9.0"
         },

--- a/dotnet-desktop-guide/net/winforms/toc.yml
+++ b/dotnet-desktop-guide/net/winforms/toc.yml
@@ -3,6 +3,10 @@ items:
   href: index.yml
 - name: What's new
   items:
+  - name: Overview
+    href: whats-new/index.md
+  - name: What's new in .NET 10 Preview
+    href: whats-new/net100.md
   - name: What's new in .NET 9.0
     href: whats-new/net90.md
   - name: What's new in .NET 8.0

--- a/dotnet-desktop-guide/net/winforms/whats-new/index.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/index.md
@@ -1,0 +1,70 @@
+---
+title: What's new in Windows Presentation Foundation
+description: Learn about what's new in Windows Presentation Foundation (WPF). This article covers changes to WPF since .NET 7 was released.
+ms.date: 02/13/2025
+ms.topic: conceptual
+ai-usage: ai-assisted
+---
+
+# What's new in Windows Presentation Foundation
+
+Each .NET release introduces a new version of Windows Forms (WinForms). This article gives you a summery of what's new in each release.
+
+## .NET 10 Preview
+
+## .NET 9
+
+WinForms in .NET 9 introduces several modern improvements. The asynchronous forms functionality provides APIs to help run UI-related operations asynchronously, making it easier to integrate with contemporary asynchronous programming patterns. The removal of BinaryFormatter eliminates a long-standing security risk by preventing unsafe deserialization practices. Additionally, experimental dark mode support has been added, allowing applications to adapt their color schemes to better suit dark environments.
+
+# List of Header Links
+
+- [Async forms](net90.md#async-forms)
+- [BinaryFormatter no longer supported](net90.md#binaryformatter-no-longer-supported)
+- [Dark mode](net90.md#dark-mode)
+- [FolderBrowserDialog enhancements](net90.md#folderbrowseerdialog-enhancements)
+- [System.Drawing new features and enhancements](net90.md#systemdrawing-new-features-and-enhancements)
+- [ToolStrip](net90.md#toolstrip)
+
+## .NET 8
+
+In .NET 8, Windows Forms has again enhanced DPI support, notably through Visual Studio DPI improvements. This enhancement allows the Windows Designer to run in a DPI-unaware mode independently from Visual Studio, ensuring that your app’s design remains sharp while Visual Studio itself stays at its native DPI setting. Another key focus area was data binding improvements and button commands.
+
+- [Data binding improvements](net80.md#data-binding-improvements)
+- [Button commands](net80.md#button-commands)
+- [Visual Studio DPI improvements](net80.md#visual-studio-dpi-improvements)
+- [High DPI improvements](net80.md#high-dpi-improvements)
+- [Miscellaneous improvements](net80.md#miscellaneous-improvements)
+
+## .NET 7
+
+In .NET 7, significant improvements have been made to High DPI rendering. These enhancements ensure that nested controls, such as buttons within panels on tab pages, scale correctly according to the current monitor's DPI settings. This feature, which is opt-in for .NET 7, will be enabled by default in .NET 8.
+
+- [Overview of WinForms on .NET 7](net70.md)
+- [High DPI improvements](net70.md#high-dpi-improvements)
+- [Accessibility improvements and fixes](net70.md#accessibility-improvements-and-fixes)
+- [Data binding improvements (preview)](net70.md#data-binding-improvements-preview)
+- [Miscellaneous improvements](net70.md#miscellaneous-improvements)
+- [See also](net70.md#see-also)
+
+## .NET 6
+
+The focus of .NET 5 for WinForms included updated templates for C# that use global directives, file-scoped namespaces, and nullable reference types. A new application bootstrap was introduced, which simplifies the configuration of Windows Forms applications by using the `ApplicationConfiguration.Initialize` method.
+
+- [Overview of WinForms on .NET 6](net60.md)
+- [Updated templates for C#](net60.md#updated-templates-for-c)
+- [New application bootstrap](net60.md#new-application-bootstrap)
+- [Change the default font](net60.md#change-the-default-font)
+- [Visual Studio designer improvements](net60.md#visual-studio-designer-improvements)
+- [High DPI improvements for PerMonitorV2](net60.md#high-dpi-improvements-for-permonitorv2)
+- [New APIs](net60.md#new-apis)
+- [Updated APIs](net60.md#updated-apis)
+- [Improved accessibility](net60.md#improved-accessibility)
+
+## .NET 5
+
+The focus of .NET 5 for WinForms was to introduce enhanced features, new controls, and improved existing controls.
+
+- [Overview of WinForms on .NET 5](net50.md)
+- [Enhanced features](net50.md#enhanced-features)
+- [New controls](net50.md#new-controls)
+- [Enhanced controls](net50.md#enhanced-controls)

--- a/dotnet-desktop-guide/net/winforms/whats-new/index.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/index.md
@@ -12,11 +12,12 @@ Each .NET release introduces a new version of Windows Forms (WinForms). This art
 
 ## .NET 10 Preview
 
+- .NET 10 Preview 1
+  - [Clipboard changes](net100.md#preview-1)
+
 ## .NET 9
 
 WinForms in .NET 9 introduces several modern improvements. The asynchronous forms functionality provides APIs to help run UI-related operations asynchronously, making it easier to integrate with contemporary asynchronous programming patterns. The removal of BinaryFormatter eliminates a long-standing security risk by preventing unsafe deserialization practices. Additionally, experimental dark mode support has been added, allowing applications to adapt their color schemes to better suit dark environments.
-
-# List of Header Links
 
 - [Async forms](net90.md#async-forms)
 - [BinaryFormatter no longer supported](net90.md#binaryformatter-no-longer-supported)

--- a/dotnet-desktop-guide/net/winforms/whats-new/index.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/index.md
@@ -1,16 +1,18 @@
 ---
-title: What's new in Windows Presentation Foundation
-description: Learn about what's new in Windows Presentation Foundation (WPF). This article covers changes to WPF since .NET 7 was released.
+title: What's new in Windows Forms
+description: Learn about what's new in Windows Forms. This article covers changes to Windows Forms since .NET 5 was released.
 ms.date: 02/13/2025
 ms.topic: conceptual
 ai-usage: ai-assisted
 ---
 
-# What's new in Windows Presentation Foundation
+# What's new in Windows Forms
 
 Each .NET release introduces a new version of Windows Forms (WinForms). This article gives you a summery of what's new in each release.
 
 ## .NET 10 Preview
+
+This section describes the main changes to WinForms for each .NET 10 Preview.
 
 - .NET 10 Preview 1
   - [Clipboard changes](net100.md#preview-1)
@@ -22,7 +24,7 @@ WinForms in .NET 9 introduces several modern improvements. The asynchronous form
 - [Async forms](net90.md#async-forms)
 - [BinaryFormatter no longer supported](net90.md#binaryformatter-no-longer-supported)
 - [Dark mode](net90.md#dark-mode)
-- [FolderBrowserDialog enhancements](net90.md#folderbrowseerdialog-enhancements)
+- [FolderBrowserDialog enhancements](net90.md#folderbrowserdialog-enhancements)
 - [System.Drawing new features and enhancements](net90.md#systemdrawing-new-features-and-enhancements)
 - [ToolStrip](net90.md#toolstrip)
 

--- a/dotnet-desktop-guide/net/winforms/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/net100.md
@@ -12,10 +12,10 @@ This article describes what's new in Windows Forms for .NET 10 Preview 1.
 
 ## Preview 1
 
-.NET 10 Preview 1 was released on February 18th, 2025.
+.NET 10 Preview 1 was released on February 18, 2025.
 
 The main improvement in WinForms for .NET 10 Preview 1 was changes to clipboard serialization and deserialization.
 
 ### Clipboard changes
 
-.NET 9 obsoleted `BinaryFormatter`, which is used in some clipboard operations. These clipboard operations required you to opt-in to compatibility package, or work around the operation. To ease the pain of moving away from `BinaryFormatter`, .NET 10 is obsoleting certain clipboard methods to indicate that they shouldn't be used. Additional methods are being added to help JSON serialization with clipboard data, circumventing the need for `BinaryFormatter`.
+.NET 9 obsoleted `BinaryFormatter`, which is used in some clipboard operations. These clipboard operations required you to opt in to compatibility package, or work around the operation. To ease the pain of moving away from `BinaryFormatter`, .NET 10 is obsoleting certain clipboard methods to indicate that they shouldn't be used. More methods are being added to help JSON serialization with clipboard data, circumventing the need for `BinaryFormatter`.

--- a/dotnet-desktop-guide/net/winforms/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/net100.md
@@ -1,0 +1,24 @@
+---
+title: What's new in WinForms for .NET 10 Preview
+description: Learn about what's new in Windows Forms for .NET 10 Preview. New versions of Windows Forms are released yearly with .NET.
+ms.topic: whats-new
+ms.date: 02/13/2025
+#customer intent: As a developer, I want to know what's changed so that I can remain up-to-date.
+---
+
+# What's new in Windows Forms for .NET 10 Preview
+
+This article describes what's new in Windows Forms for .NET 10 Preview 1.
+
+## Preview 1
+
+.NET 10 Preview 1 was released on February 18th, 2025.
+
+For WPF, .NET 10 only included a few minor patches and bug fixes. Key areas are:
+
+- Over 4,000 unit tests for `System.Xaml` and `WindowsBase` added.
+- Fluent Theme issue fixes, including a **HighContrast** crash.
+- Cleanup of CAS attributes.
+  - Remove unused CAS resource strings and its translations from all libraries.
+  - Remove `OleCmdHelper/ISecureCommand` dead code (CAS/XBAP leftovers).
+  - Remove dead code in `FontSourceCollection/FontSource` (+ hollow CAS remnants).

--- a/dotnet-desktop-guide/net/winforms/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/net100.md
@@ -14,11 +14,8 @@ This article describes what's new in Windows Forms for .NET 10 Preview 1.
 
 .NET 10 Preview 1 was released on February 18th, 2025.
 
-For WPF, .NET 10 only included a few minor patches and bug fixes. Key areas are:
+The main improvement in WinForms for .NET 10 Preview 1 was changes to clipboard serialization and deserialization.
 
-- Over 4,000 unit tests for `System.Xaml` and `WindowsBase` added.
-- Fluent Theme issue fixes, including a **HighContrast** crash.
-- Cleanup of CAS attributes.
-  - Remove unused CAS resource strings and its translations from all libraries.
-  - Remove `OleCmdHelper/ISecureCommand` dead code (CAS/XBAP leftovers).
-  - Remove dead code in `FontSourceCollection/FontSource` (+ hollow CAS remnants).
+### Clipboard changes
+
+.NET 9 obsoleted `BinaryFormatter`, which is used in some clipboard operations. These clipboard operations required you to opt-in to compatibility package, or work around the operation. To ease the pain of moving away from `BinaryFormatter`, .NET 10 is obsoleting certain clipboard methods to indicate that they shouldn't be used. Additional methods are being added to help JSON serialization with clipboard data, circumventing the need for `BinaryFormatter`.

--- a/dotnet-desktop-guide/net/winforms/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/winforms/whats-new/net100.md
@@ -12,7 +12,7 @@ This article describes what's new in Windows Forms for .NET 10 Preview 1.
 
 ## Preview 1
 
-.NET 10 Preview 1 was released on February 18, 2025.
+.NET 10 Preview 1 was released on February 20, 2025.
 
 The main improvement in WinForms for .NET 10 Preview 1 was changes to clipboard serialization and deserialization.
 

--- a/dotnet-desktop-guide/net/wpf/toc.yml
+++ b/dotnet-desktop-guide/net/wpf/toc.yml
@@ -12,6 +12,8 @@ items:
   items:
   - name: Overview
     href: whats-new/index.md
+  - name: What's new in .NET 10 Preview
+    href: whats-new/net100.md
   - name: What's new in .NET 9
     href: whats-new/net90.md
   - name: What's new in .NET 8

--- a/dotnet-desktop-guide/net/wpf/whats-new/index.md
+++ b/dotnet-desktop-guide/net/wpf/whats-new/index.md
@@ -11,6 +11,8 @@ Each .NET release introduces a new version of Windows Presentation Foundation (W
 
 ## .NET 10 Preview
 
+This section describes the main changes to WPF for each .NET 10 Preview.
+
 - .NET 10 Preview 1
   - [4000+ unit tests for `System.XAML` and `WindowsBase`](net100.md#preview-1)
   - [Fluent theme fixes](net100.md#preview-1)

--- a/dotnet-desktop-guide/net/wpf/whats-new/index.md
+++ b/dotnet-desktop-guide/net/wpf/whats-new/index.md
@@ -9,6 +9,12 @@ ms.topic: conceptual
 
 Each .NET release introduces a new version of Windows Presentation Foundation (WPF). This article teaches you what's new in each release.
 
+## .NET 10 Preview
+
+- .NET 10 Preview 1
+  - [4000+ unit tests for `System.XAML` and `WindowsBase`](net100.md#preview-1)
+  - [Fluent theme fixes](net100.md#preview-1)
+
 ## .NET 9
 
 More support for building modern apps with WPF with several theming enhancements:

--- a/dotnet-desktop-guide/net/wpf/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/wpf/whats-new/net100.md
@@ -12,4 +12,13 @@ This article describes what's new in Windows Presentation Foundation (WPF) for .
 
 ## Preview 1
 
-.NET 10 Preview 1 was released on February 18th, 2025.
+.NET 10 Preview 1 was released on February 18, 2025.
+
+For WPF, .NET 10 only included a few minor patches and bug fixes. Key areas are:
+
+- Over 4,000 unit tests for `System.Xaml` and `WindowsBase` added.
+- Fluent Theme issue fixes, including a **HighContrast** crash.
+- Cleanup of CAS (Code Access Security) attributes.
+  - Remove unused CAS resource strings and its translations from all libraries.
+  - Remove `OleCmdHelper/ISecureCommand` dead code (CAS/XBAP leftovers).
+  - Remove dead code in `FontSourceCollection/FontSource` (+ hollow CAS remnants).

--- a/dotnet-desktop-guide/net/wpf/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/wpf/whats-new/net100.md
@@ -1,0 +1,15 @@
+---
+title: What's new in WPF for .NET 10 Preview
+description: Learn about what's new in Windows Presentation Foundation (WPF) for .NET 10 Preview. New versions of WPF are released yearly with .NET.
+ms.topic: whats-new
+ms.date: 02/13/2025
+#customer intent: As a developer, I want to know what's changed so that I can remain up-to-date.
+---
+
+# What's new in WPF for .NET 10 Preview
+
+This article describes what's new in Windows Presentation Foundation (WPF) for .NET 10 Preview.
+
+## Preview 1
+
+.NET 10 Preview 1 was released on February 18th, 2025.

--- a/dotnet-desktop-guide/net/wpf/whats-new/net100.md
+++ b/dotnet-desktop-guide/net/wpf/whats-new/net100.md
@@ -12,7 +12,7 @@ This article describes what's new in Windows Presentation Foundation (WPF) for .
 
 ## Preview 1
 
-.NET 10 Preview 1 was released on February 18, 2025.
+.NET 10 Preview 1 was released on February 20, 2025.
 
 For WPF, .NET 10 only included a few minor patches and bug fixes. Key areas are:
 
@@ -20,5 +20,5 @@ For WPF, .NET 10 only included a few minor patches and bug fixes. Key areas are:
 - Fluent Theme issue fixes, including a **HighContrast** crash.
 - Cleanup of CAS (Code Access Security) attributes.
   - Remove unused CAS resource strings and its translations from all libraries.
-  - Remove `OleCmdHelper/ISecureCommand` dead code (CAS/XBAP leftovers).
-  - Remove dead code in `FontSourceCollection/FontSource` (+ hollow CAS remnants).
+  - Remove unused CAS and XBAP code from `OleCmdHelper/ISecureCommand`.
+  - Remove unused CAS code from `FontSourceCollection/FontSource`.

--- a/redirects_generator/definitions.winforms.json
+++ b/redirects_generator/definitions.winforms.json
@@ -22,13 +22,6 @@
             "SourceUrl": "/dotnet/desktop/winforms/controls-design/extend-existing?view=netdesktop-9.0",
             "TargetUrl": "/dotnet/desktop/winforms/controls-design/how-to-extend-existing?view=netdesktop-9.0"
         },
-
-        // Index mappings
-        {
-            "Redirect": "Normal",
-            "SourceUrl": "/dotnet/desktop/winforms/whats-new/index?view=netdesktop-9.0",
-            "TargetUrl": "/dotnet/desktop/winforms/whats-new/net90?view=netdesktop-9.0"
-        },
         {
             "Redirect": "Normal",
             "SourceUrl": "/dotnet/desktop/winforms/controls-design/index?view=netdesktop-9.0",


### PR DESCRIPTION
- Add what's new for .NET 10 Preview 1 WPF/WinForms.
- Created `index.md` for WinForms to summarize the changes in all versions.
- Removed redirect for the WinForms `index` article.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/winforms/whats-new/index.md](https://github.com/dotnet/docs-desktop/blob/7e3f310c20140d035886ad0c7be4ab459cb672f8/dotnet-desktop-guide/net/winforms/whats-new/index.md) | [dotnet-desktop-guide/net/winforms/whats-new/index](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/whats-new/index?branch=pr-en-us-2006&view=netdesktop-9.0) |
| [dotnet-desktop-guide/net/winforms/whats-new/net100.md](https://github.com/dotnet/docs-desktop/blob/7e3f310c20140d035886ad0c7be4ab459cb672f8/dotnet-desktop-guide/net/winforms/whats-new/net100.md) | [dotnet-desktop-guide/net/winforms/whats-new/net100](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/whats-new/net100?branch=pr-en-us-2006&view=netdesktop-9.0) |
| [dotnet-desktop-guide/net/wpf/whats-new/index.md](https://github.com/dotnet/docs-desktop/blob/7e3f310c20140d035886ad0c7be4ab459cb672f8/dotnet-desktop-guide/net/wpf/whats-new/index.md) | [dotnet-desktop-guide/net/wpf/whats-new/index](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/whats-new/index?branch=pr-en-us-2006&view=netdesktop-9.0) |
| [dotnet-desktop-guide/net/wpf/whats-new/net100.md](https://github.com/dotnet/docs-desktop/blob/7e3f310c20140d035886ad0c7be4ab459cb672f8/dotnet-desktop-guide/net/wpf/whats-new/net100.md) | [dotnet-desktop-guide/net/wpf/whats-new/net100](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/whats-new/net100?branch=pr-en-us-2006&view=netdesktop-9.0) |


<!-- PREVIEW-TABLE-END -->