### PR TITLE
Fix minor typos in treeview-styles-and-templates.md

### DIFF
--- a/dotnet-desktop-guide/framework/wpf/controls/treeview-styles-and-templates.md
+++ b/dotnet-desktop-guide/framework/wpf/controls/treeview-styles-and-templates.md
@@ -28,8 +28,8 @@ This topic describes the styles and templates for the <xref:System.Windows.Contr
 |VisualState Name|VisualStateGroup Name|Description|  
 |-|-|-|  
 |Valid|ValidationStates|The control uses the <xref:System.Windows.Controls.Validation> class and the <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `false`.|  
-|InvalidFocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` has the control has focus.|  
-|InvalidUnfocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` has the control does not have focus.|  
+|InvalidFocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` and the control has focus.|  
+|InvalidUnfocused|ValidationStates|The <xref:System.Windows.Controls.Validation.HasError%2A?displayProperty=nameWithType> attached property is `true` and the control does not have focus.|  
   
 ## TreeViewItem Parts  
 
@@ -37,7 +37,7 @@ This topic describes the styles and templates for the <xref:System.Windows.Contr
   
 |Part|Type|Description|  
 |----------|----------|-----------------|  
-|PART_Header|<xref:System.Windows.FrameworkElement>|A visual element that contains that header content of the <xref:System.Windows.Controls.TreeView> control.|  
+|PART_Header|<xref:System.Windows.FrameworkElement>|A visual element that contains the header content of the <xref:System.Windows.Controls.TreeView> control.|  
   
 ## TreeViewItem States  
 


### PR DESCRIPTION
## Summary

Fixed three minor typos in the treeview-styles-and-templates.md file.

More specifically in the TreeView states table and the TreeViewItem parts table.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/wpf/controls/treeview-styles-and-templates.md](https://github.com/dotnet/docs-desktop/blob/e79501cc94ff399614c928c571a18930eb3c4b23/dotnet-desktop-guide/framework/wpf/controls/treeview-styles-and-templates.md) | [dotnet-desktop-guide/framework/wpf/controls/treeview-styles-and-templates](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/controls/treeview-styles-and-templates?branch=pr-en-us-2020&view=netframeworkdesktop-4.8) |

<!-- PREVIEW-TABLE-END -->