### PR TITLE
Update wfo1000.md

### DIFF
--- a/dotnet-desktop-guide/net/winforms/compiler-messages/wfo1000.md
+++ b/dotnet-desktop-guide/net/winforms/compiler-messages/wfo1000.md
@@ -18,9 +18,6 @@ Properties of classes derived from <xref:System.Windows.Forms.Control> must indi
 
 By default, the Windows Forms designer serializes every public property of a <xref:System.Windows.Forms.Control> that doesn't specify a serialization preference. This might result in leaking private data into the designer's serialization of the control. This error ensures that you explicitly declare the serialization of every public property of the control.
 
-> [!IMPORTANT]
-> This analyzer message was changed from an error in .NET 9 to a warning in .NET 10 Preview 2.
-
 ## To correct this error
 
 Indicate serialization of the property.


### PR DESCRIPTION
I removed the call out that this Error was downgraded to a warning, it wasn't in fact.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/net/winforms/compiler-messages/wfo1000.md](https://github.com/dotnet/docs-desktop/blob/87e654a7603f100b21d53cd66ed1931db4a11176/dotnet-desktop-guide/net/winforms/compiler-messages/wfo1000.md) | [dotnet-desktop-guide/net/winforms/compiler-messages/wfo1000](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/compiler-messages/wfo1000?branch=pr-en-us-2029&view=netdesktop-9.0) |

<!-- PREVIEW-TABLE-END -->