### PR TITLE
Run Sequester monthly

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -2,6 +2,7 @@ name: "bulk quest import"
 on:
   schedule:
     - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
+    - cron: '0 9 6 * *'  # This is the morning of the 6th.
   workflow_dispatch:
     inputs:
       reason:
@@ -56,4 +57,4 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: '-1'
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || 5 }}
+          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 9 6 * *' && -1 || 5 }}


### PR DESCRIPTION
This mode runs on all open issues. Any issues that are open, but only in past sprints, are moved to the backlog sprint.
