### PR TITLE
Fix font not using the provided family.

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/advanced/snippets/how-to-create-a-private-font-collection/cs/Form1.cs
+++ b/dotnet-desktop-guide/framework/winforms/advanced/snippets/how-to-create-a-private-font-collection/cs/Form1.cs
@@ -32,7 +32,7 @@ namespace fonts
             string familyNameAndStyle = $"{family.Name} {styleName}";
 
             // Create the font object
-            using (Font fontObject = new Font(family.Name, 16, style, GraphicsUnit.Pixel))
+            using (Font fontObject = new Font(family, 16, style, GraphicsUnit.Pixel))
             {
                 // Draw the string
                 graphicsObj.DrawString(familyNameAndStyle, fontObject, colorBrush, location);

--- a/dotnet-desktop-guide/framework/winforms/advanced/snippets/how-to-create-a-private-font-collection/vb/Form1.vb
+++ b/dotnet-desktop-guide/framework/winforms/advanced/snippets/how-to-create-a-private-font-collection/vb/Form1.vb
@@ -15,7 +15,7 @@ Public Class Form1
         Dim familyNameAndStyle As String = $"{family.Name} {styleName}"
 
         ' Create the font object
-        Using fontObject As New Font(family.Name, 16, style, GraphicsUnit.Pixel)
+        Using fontObject As New Font(family, 16, style, GraphicsUnit.Pixel)
 
             ' Draw the string
             graphicsObj.DrawString(familyNameAndStyle, fontObject, colorBrush, location)


### PR DESCRIPTION
## Summary

Font code now uses the font family object provided, instead of the name. I unfortunately rewrote this sample about 5 months ago and continued this bug, not noticing the linked issue.

This is fixed now and allows you to load fonts not installed by the system.

Fixes #1018
