### PR TITLE
Clarify print preview usage in winforms

### DIFF
--- a/dotnet-desktop-guide/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms.md
+++ b/dotnet-desktop-guide/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms.md
@@ -31,25 +31,29 @@ To apply the optimization, set the `Switch.System.Drawing.Printing.OptimizePrint
 
 # [.NET](#tab/dotnet)
 
-The option can be set in the runtimeconfig.json configuration file or the project file of an app:
+The option can be set in the _runtimeconfig.json_ configuration file or the project file of an app:
 
-- **Set in the project file.**
+- **Configure a default in project file.**
 
-  As an alternative to using the _runtimeconfig.template.json_ file, apply the setting in the project file. Add the `<RuntimeHostConfigurationOption>` setting to an `<ItemGroup>`:
+  To apply the setting in the project file, enable runtime config generation by setting `<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>` to in a `<PropertyGroup>`. Then, add the `<RuntimeHostConfigurationOption>` setting to an `<ItemGroup>`:
 
   ```xml
   <Project Sdk="Microsoft.NET.Sdk">
-  
+
     <!-- Other project settings ... -->  
-  
-    <ItemGroup>
+
+    <PropertyGroup>
+      <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    </PropertyGroup>
+
+    <ItemGroup>      
       <RuntimeHostConfigurationOption Include="Switch.System.Drawing.Printing.OptimizePrintPreview" Value="true" />
     </ItemGroup>
-  
+
   </Project>
   ```
 
-- **Set in the _runtimeconfig.template.json_ source file.**
+- **Configure a default in the _runtimeconfig.template.json_ source file.**
 
   To configure the default setting for your app, apply the setting in the _runtimeconfig.template.json_ source file. When the app is compiled or published, the template file is used to generate a runtime config file.
 
@@ -63,7 +67,7 @@ The option can be set in the runtimeconfig.json configuration file or the projec
 
   For more information about runtime config, see [.NET runtime configuration settings](/dotnet/core/runtime-config/).
 
-- **Set in the _{appname}.runtimeconfig.json_ output file.**
+- **Configure a published app with the _{appname}.runtimeconfig.json_ output file.**
 
   To configure the published app, apply the setting in the _{appname}.runtimeconfig.json_ file's `runtimeOptions/configProperties` section.
 


### PR DESCRIPTION
## Summary

- Presented the content as "the way it works" regardless of framework version.
- Moved 4.5.2 as a special tip with a note that it's no longer supported.
- Clarified that the optimization isn't applied when you use the event to modify page settings.
- Ran acro on the content

@Tanya-Solyanik 

Fixes #1546


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms.md](https://github.com/dotnet/docs-desktop/blob/6401ddda64fdc79e7158b2a7b99d40d9bd5d38b6/dotnet-desktop-guide/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms.md) | [dotnet-desktop-guide/framework/winforms/controls/printpreviewdialog-control-overview-windows-forms](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/printpreviewdialog-control-overview-windows-forms?branch=pr-en-us-2051&view=netframeworkdesktop-4.8) |


<!-- PREVIEW-TABLE-END -->