### PR TITLE
Stagger run times

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,7 +1,7 @@
 name: "bulk quest import"
 on:
   schedule:
-    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
+    - cron: '0 9 1-5,7-31 * *' # UTC time, that's 4:00 am EST, 1:00 am PST.
     - cron: '0 9 6 * *'  # This is the morning of the 6th.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -67,7 +67,7 @@ jobs:
       - name: auto-sequester
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: auto-sequester
-        uses: dotnet/docs-tools/actions/sequester@5e8bcc78465d45a7544bba56509a1a69922b6a5a # main
+        uses: dotnet/docs-tools/actions/sequester@main
         env:
           ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
           ImportOptions__ApiKeys__AzureAccessToken: ${{ steps.azure-oidc-auth.outputs.access-token }}


### PR DESCRIPTION
Stagger the run times based on [this table](https://github.com/dotnet/docs-tools/tree/main/actions/sequester#staggering-times)

That prevents us from getting rate limited.
