### PR TITLE
Fix GitHub link in thread-safe calls documentation

### DIFF
--- a/dotnet-desktop-guide/winforms/controls/how-to-make-thread-safe-calls.md
+++ b/dotnet-desktop-guide/winforms/controls/how-to-make-thread-safe-calls.md
@@ -108,7 +108,7 @@ For async operations that need to run on the UI thread, use the async overload:
 :::code language="vb" source="snippets/how-to-make-thread-safe-calls/vb/FormInvokeAsync.vb" id="snippet_InvokeAsyncAdvanced":::
 
 > [!NOTE]
-> If you're using Visual Basic, the previous code snippet used an extension method to convert a <xref:System.Threading.Tasks.ValueTask> to a <xref:System.Threading.Tasks.Task>. The extension method code is available on [GitHub](https://github.com/dotnet/docs-desktop/blob/main/dotnet-desktop-guide/winforms/forms/snippets/how-to-make-thread-safe-calls/vb/Extensions.vb).
+> If you're using Visual Basic, the previous code snippet used an extension method to convert a <xref:System.Threading.Tasks.ValueTask> to a <xref:System.Threading.Tasks.Task>. The extension method code is available on [GitHub](https://github.com/dotnet/docs-desktop/blob/main/dotnet-desktop-guide/winforms/controls/snippets/how-to-make-thread-safe-calls/vb/Extensions.vb).
 
 ## Example: Use the Control.Invoke method
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/docs/issues/46532.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/winforms/controls/how-to-make-thread-safe-calls.md](https://github.com/dotnet/docs-desktop/blob/2b9bc73b6fcb0f051bd7dd19fbb807f45fd9d440/dotnet-desktop-guide/winforms/controls/how-to-make-thread-safe-calls.md) | [dotnet-desktop-guide/winforms/controls/how-to-make-thread-safe-calls](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/how-to-make-thread-safe-calls?branch=pr-en-us-2127) |

<!-- PREVIEW-TABLE-END -->