### PR TITLE
Add info on new row/column definition functionality for WPF in .NET 10

### DIFF
--- a/dotnet-desktop-guide/wpf/whats-new/net100.md
+++ b/dotnet-desktop-guide/wpf/whats-new/net100.md
@@ -146,8 +146,7 @@ Community contributor **dotMorten** enhanced the Grid row and columns definition
 can now be written as follows:
 
 ```xaml
-<Grid ColumnDefinitions="1*, 2*, Auto, *, 300" RowDefinitions="1*, Auto, 25, 14, 20"/>
-</Grid>
+<Grid ColumnDefinitions="1*, 2*, Auto, *, 300" RowDefinitions="1*, Auto, 25, 14, 20" />
 ```
 
 For more information, see [#1739](https://github.com/dotnet/wpf/issues/1739).


### PR DESCRIPTION
## Summary

Adds some missing info to the 'What's new in WPF for .NET 10' article. This is a really nice enhancement that I don't think should be missed

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/wpf/whats-new/net100.md](https://github.com/dotnet/docs-desktop/blob/61a514f927a37290fff0609fc754fdbea136e4d2/dotnet-desktop-guide/wpf/whats-new/net100.md) | [dotnet-desktop-guide/wpf/whats-new/net100](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/whats-new/net100?branch=pr-en-us-2175) |


<!-- PREVIEW-TABLE-END -->