### PR TITLE
Format links in unmanaged API reference

### DIFF
--- a/dotnet-desktop-guide/wpf/advanced/wpf-unmanaged-api-reference.md
+++ b/dotnet-desktop-guide/wpf/advanced/wpf-unmanaged-api-reference.md
@@ -12,14 +12,14 @@ Windows Presentation Foundation (WPF) libraries expose a number of unmanaged fun
 
 ## In This Section
 
-[Activate Function](activate-function-wpf-unmanaged-api-reference.md)
-[CreateIDispatchSTAForwarder Function](createidispatchstaforwarder-function-wpf-unmanaged-api-reference.md)
-[Deactivate Function](deactivate-function-wpf-unmanaged-api-reference.md)
-[ForwardTranslateAccelerator Function](forwardtranslateaccelerator-function-wpf-unmanaged-api-reference.md)
-[LoadFromHistory Function](loadfromhistory-function-wpf-unmanaged-api-reference.md)
-[ProcessUnhandledException Function](processunhandledexception-function-wpf-unmanaged-api-reference.md)
-[SaveToHistory Function](savetohistory-function-wpf-unmanaged-api-reference.md)
-[SetFakeActiveWindow Function](setfakeactivewindow-function-wpf-unmanaged-api-reference.md)
+- [Activate Function](activate-function-wpf-unmanaged-api-reference.md)
+- [CreateIDispatchSTAForwarder Function](createidispatchstaforwarder-function-wpf-unmanaged-api-reference.md)
+- [Deactivate Function](deactivate-function-wpf-unmanaged-api-reference.md)
+- [ForwardTranslateAccelerator Function](forwardtranslateaccelerator-function-wpf-unmanaged-api-reference.md)
+- [LoadFromHistory Function](loadfromhistory-function-wpf-unmanaged-api-reference.md)
+- [ProcessUnhandledException Function](processunhandledexception-function-wpf-unmanaged-api-reference.md)
+- [SaveToHistory Function](savetohistory-function-wpf-unmanaged-api-reference.md)
+- [SetFakeActiveWindow Function](setfakeactivewindow-function-wpf-unmanaged-api-reference.md)
 
 ## See also
 


### PR DESCRIPTION
## Summary

Updated the formatting of the unmanaged API reference section. Just was on the page and noticed the list format was wrong. Looked at one of the other pages to verify this is the correct unordered list syntax to use.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/wpf/advanced/wpf-unmanaged-api-reference.md](https://github.com/dotnet/docs-desktop/blob/5ad761504991917e5e7bc287c4a0804731eb8a29/dotnet-desktop-guide/wpf/advanced/wpf-unmanaged-api-reference.md) | [dotnet-desktop-guide/wpf/advanced/wpf-unmanaged-api-reference](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/wpf-unmanaged-api-reference?branch=pr-en-us-2201) |

<!-- PREVIEW-TABLE-END -->