### PR TITLE
Fix grammar in how-to-create-a-simple-binding.md

### DIFF
--- a/dotnet-desktop-guide/wpf/data/how-to-create-a-simple-binding.md
+++ b/dotnet-desktop-guide/wpf/data/how-to-create-a-simple-binding.md
@@ -51,7 +51,7 @@ The following XAML demonstrates using the `Employee` class as a data object. The
 
     :::code language="xaml" source="./snippets/how-to-create-a-simple-binding/csharp/EmployeeView.xaml" highlight="7-9,33-37,43":::
 
-The namespace of the code won't match your project's namespace, unless you created a project named **ArticleSample**. You can copy and paste the `Window.Resources` and root element (`StackPanel`) into you're **MainWindow** if you created a new project.
+The namespace of the code won't match your project's namespace, unless you created a project named **ArticleSample**. You can copy and paste the `Window.Resources` and root element (`StackPanel`) into your **MainWindow** if you created a new project.
 
 To better understand how the previous XAML is using data binding, consider the following points:
 


### PR DESCRIPTION
Fixed grammar (or likely just a typo) on line 54 from "..you're **MainWindow**" to "...your **MainWindow**"



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/wpf/data/how-to-create-a-simple-binding.md](https://github.com/dotnet/docs-desktop/blob/173cd1a0fd8797241fe62783c52297e98437bccd/dotnet-desktop-guide/wpf/data/how-to-create-a-simple-binding.md) | [dotnet-desktop-guide/wpf/data/how-to-create-a-simple-binding](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-create-a-simple-binding?branch=pr-en-us-2227) |

<!-- PREVIEW-TABLE-END -->