### PR TITLE
Fix incorrect usage of regex in WPF sample

### DIFF
--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/DialogBoxSample/CSharp/FindDialogBox.xaml.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/DialogBoxSample/CSharp/FindDialogBox.xaml.cs
@@ -53,16 +53,24 @@ namespace SDKSample
             // Find matches
             if (this.matches == null)
             {
-                string pattern = this.findWhatTextBox.Text;
+                RegexOptions regexOptions = RegexOptions.None;
+                string literalToFind = this.findWhatTextBox.Text;
+
+                // Escape the user-typed text in case it contains regex special characters.
+                string pattern = Regex.Escape(literalToFind);
 
                 // Match whole word?
-                if ((bool)this.matchWholeWordCheckBox.IsChecked) pattern = @"(?<=\W{0,1})" + pattern + @"(?=\W)";
+                if ((bool)this.matchWholeWordCheckBox.IsChecked)
+                {
+                    if (BeginsWithRegexWordChar(literalToFind)) pattern = @"\b" + pattern;
+                    if (EndsWithRegexWordChar(literalToFind)) pattern = pattern + @"\b";
+                }
 
                 // Case sensitive
-                if (!(bool)this.caseSensitiveCheckBox.IsChecked) pattern = "(?i)" + pattern;
+                if (!(bool)this.caseSensitiveCheckBox.IsChecked) regexOptions |= RegexOptions.IgnoreCase;
 
                 // Find matches
-                this.matches = Regex.Matches(this.textBoxToSearch.Text, pattern);
+                this.matches = Regex.Matches(this.textBoxToSearch.Text, pattern, regexOptions);
                 this.matchIndex = 0;
 
                 // Word not found?
@@ -77,7 +85,7 @@ namespace SDKSample
             // Start at beginning of matches if the last find selected the last match
             if (this.matchIndex == this.matches.Count)
             {
-                MessageBoxResult result = MessageBox.Show("Nmore matches found. Start at beginning?", "Find", MessageBoxButton.YesNo);
+                MessageBoxResult result = MessageBox.Show("No more matches found. Start at beginning?", "Find", MessageBoxButton.YesNo);
                 if (result == MessageBoxResult.No) return;
 
                 // Reset
@@ -94,6 +102,18 @@ namespace SDKSample
                 OnTextFound();
             }
             this.matchIndex++;
+        }
+
+        static bool BeginsWithRegexWordChar(string literal)
+        {
+            if (string.IsNullOrEmpty(literal)) return false;
+            return Regex.IsMatch(literal[0].ToString(), @"\w");
+        }
+
+        static bool EndsWithRegexWordChar(string literal)
+        {
+            if (string.IsNullOrEmpty(literal)) return false;
+            return Regex.IsMatch(literal[literal.Length - 1].ToString(), @"\w");
         }
 
         void textBoxToSearch_TextChanged(object sender, TextChangedEventArgs e)

--- a/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/DialogBoxSample/CSharp/FindDialogBox.xaml.cs
+++ b/dotnet-desktop-guide/samples/snippets/csharp/VS_Snippets_Wpf/DialogBoxSample/CSharp/FindDialogBox.xaml.cs
@@ -50,20 +50,24 @@ namespace SDKSample
 
         void findNextButton_Click(object sender, RoutedEventArgs e)
         {
+            string textToFind = this.findWhatTextBox.Text;
+
+            // Short-circuit: Did the user not provide any text at all?
+            if (string.IsNullOrEmpty(textToFind)) return;
+
             // Find matches
             if (this.matches == null)
             {
                 RegexOptions regexOptions = RegexOptions.None;
-                string literalToFind = this.findWhatTextBox.Text;
 
                 // Escape the user-typed text in case it contains regex special characters.
-                string pattern = Regex.Escape(literalToFind);
+                string pattern = Regex.Escape(textToFind);
 
                 // Match whole word?
                 if ((bool)this.matchWholeWordCheckBox.IsChecked)
                 {
-                    if (BeginsWithRegexWordChar(literalToFind)) pattern = @"\b" + pattern;
-                    if (EndsWithRegexWordChar(literalToFind)) pattern = pattern + @"\b";
+                    if (BeginsWithRegexWordChar(textToFind)) pattern = @"\b" + pattern;
+                    if (EndsWithRegexWordChar(textToFind)) pattern = pattern + @"\b";
                 }
 
                 // Case sensitive

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/DialogBoxSample/VisualBasic/FindDialogBox.xaml.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/DialogBoxSample/VisualBasic/FindDialogBox.xaml.vb
@@ -33,17 +33,21 @@ Namespace SDKSample
         End Sub
 
         Private Sub findNextButton_Click(ByVal sender As Object, ByVal e As RoutedEventArgs)
+            Dim textToFind As String = Me.findWhatTextBox.Text
+
+            ' Short-circuit: Did the user not provide any text at all?
+            If String.IsNullOrEmpty(textToFind) Then Return
+
             If (Me.matches Is Nothing) Then
                 Dim matchOptions As RegexOptions = RegexOptions.None
-                Dim literalToFind As String = Me.findWhatTextBox.Text
 
                 ' Escape the user-typed text in case it contains regex special characters.
-                Dim pattern As String = Regex.Escape(literalToFind)
+                Dim pattern As String = Regex.Escape(textToFind)
 
                 ' Match whole word?
                 If Me.matchWholeWordCheckBox.IsChecked.Value Then
-                    If BeginsWithRegexWordChar(literalToFind) Then pattern = "\b" & pattern
-                    If EndsWithRegexWordChar(literalToFind) Then pattern = pattern & "\b"
+                    If BeginsWithRegexWordChar(textToFind) Then pattern = "\b" & pattern
+                    If EndsWithRegexWordChar(textToFind) Then pattern = pattern & "\b"
                 End If
 
                 ' Case sensitive

--- a/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/DialogBoxSample/VisualBasic/FindDialogBox.xaml.vb
+++ b/dotnet-desktop-guide/samples/snippets/visualbasic/VS_Snippets_Wpf/DialogBoxSample/VisualBasic/FindDialogBox.xaml.vb
@@ -34,14 +34,23 @@ Namespace SDKSample
 
         Private Sub findNextButton_Click(ByVal sender As Object, ByVal e As RoutedEventArgs)
             If (Me.matches Is Nothing) Then
-                Dim pattern As String = Me.findWhatTextBox.Text
+                Dim matchOptions As RegexOptions = RegexOptions.None
+                Dim literalToFind As String = Me.findWhatTextBox.Text
+
+                ' Escape the user-typed text in case it contains regex special characters.
+                Dim pattern As String = Regex.Escape(literalToFind)
+
+                ' Match whole word?
                 If Me.matchWholeWordCheckBox.IsChecked.Value Then
-                    pattern = ("(?<=\W{0,1})" & pattern & "(?=\W)")
+                    If BeginsWithRegexWordChar(literalToFind) Then pattern = "\b" & pattern
+                    If EndsWithRegexWordChar(literalToFind) Then pattern = pattern & "\b"
                 End If
-                If Not Me.caseSensitiveCheckBox.IsChecked.Value Then
-                    pattern = ("(?i)" & pattern)
-                End If
-                Me.matches = Regex.Matches(Me.textBoxToSearch.Text, pattern)
+
+                ' Case sensitive
+                If Not Me.caseSensitiveCheckBox.IsChecked.Value Then matchOptions = matchOptions Or RegexOptions.IgnoreCase
+
+                ' Find matches
+                Me.matches = Regex.Matches(Me.textBoxToSearch.Text, pattern, matchOptions)
                 Me.matchIndex = 0
                 If (Me.matches.Count = 0) Then
                     MessageBox.Show(("'" & Me.findWhatTextBox.Text & "' not found."), "Find")
@@ -50,7 +59,7 @@ Namespace SDKSample
                 End If
             End If
             If (Me.matchIndex = Me.matches.Count) Then
-                Dim result As MessageBoxResult = MessageBox.Show("Nmore matches found. Start at beginning?", "Find", MessageBoxButton.YesNo)
+                Dim result As MessageBoxResult = MessageBox.Show("No more matches found. Start at beginning?", "Find", MessageBoxButton.YesNo)
                 If (result = MessageBoxResult.No) Then
                     Return
                 End If
@@ -64,6 +73,16 @@ Namespace SDKSample
 
             Me.matchIndex += 1
         End Sub
+
+        Private Shared Function BeginsWithRegexWordChar(ByVal literal As String) As Boolean
+            If String.IsNullOrEmpty(literal) Then Return False
+            Return Regex.IsMatch(literal(0).ToString(), "\w")
+        End Function
+
+        Private Shared Function EndsWithRegexWordChar(ByVal literal As String) As Boolean
+            If String.IsNullOrEmpty(literal) Then Return False
+            Return Regex.IsMatch(literal(literal.Length - 1).ToString(), "\w")
+        End Function
 
         Private Sub findWhatTextBox_TextChanged(ByVal sender As Object, ByVal e As TextChangedEventArgs)
             Me.ResetFind()


### PR DESCRIPTION
I'm updating regex docs across the various docs repos. This is one part of that update.

Changes:
- Demonstrates proper use of regex escaping when searching for an input string.
- Demonstrates proper use of word boundaries.
- Corrects a typo.

Related PRs:
- https://github.com/dotnet/docs-desktop/pull/2250 (this one)
- https://github.com/dotnet/docs/pull/54621
- https://github.com/dotnet/dotnet-api-docs/pull/12848
- https://github.com/dotnet/runtime/pull/130271