### PR TITLE
Document KeyPreview exceptions and keyboard interception guidance for WinForms

### DIFF
--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-change-key-press.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-change-key-press.md
@@ -1,7 +1,7 @@
 ---
 title: "Modify keyboard key events"
 description: Learn how to intercept a key press and modify which key is pressed on a Windows Forms .NET application.
-ms.date: 04/02/2025
+ms.date: 07/02/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 dev_langs:
@@ -19,14 +19,14 @@ Windows Forms can consume and modify keyboard input. Consuming a key refers to h
 
 ## Consume a key
 
-In a <xref:System.Windows.Forms.Control.KeyPress> event handler, set the <xref:System.Windows.Forms.KeyPressEventArgs.Handled%2A> property of the <xref:System.Windows.Forms.KeyPressEventArgs> class to `true`.
+In a <xref:System.Windows.Forms.Control.KeyPress> event handler, set the <xref:System.Windows.Forms.KeyPressEventArgs.Handled*> property of the <xref:System.Windows.Forms.KeyPressEventArgs> class to `true`.
 
 -or-
 
-In a <xref:System.Windows.Forms.Control.KeyDown> event handler, set the <xref:System.Windows.Forms.KeyEventArgs.Handled%2A> property of the <xref:System.Windows.Forms.KeyEventArgs> class to `true`.
+In a <xref:System.Windows.Forms.Control.KeyDown> event handler, set the <xref:System.Windows.Forms.KeyEventArgs.Handled*> property of the <xref:System.Windows.Forms.KeyEventArgs> class to `true`.
 
 > [!NOTE]
-> Setting the <xref:System.Windows.Forms.KeyEventArgs.Handled%2A> property in the <xref:System.Windows.Forms.Control.KeyDown> event handler doesn't prevent the <xref:System.Windows.Forms.Control.KeyPress> and <xref:System.Windows.Forms.Control.KeyUp> events from being raised for the current keystroke. Use the <xref:System.Windows.Forms.KeyEventArgs.SuppressKeyPress%2A> property for this purpose.
+> Setting the <xref:System.Windows.Forms.KeyEventArgs.Handled*> property in the <xref:System.Windows.Forms.Control.KeyDown> event handler doesn't prevent the <xref:System.Windows.Forms.Control.KeyPress> and <xref:System.Windows.Forms.Control.KeyUp> events from being raised for the current keystroke. Use the <xref:System.Windows.Forms.KeyEventArgs.SuppressKeyPress*> property for this purpose.
 
 The following example handles the <xref:System.Windows.Forms.Control.KeyPress> event to consume the `A` and `a` character keys. Those keys can't be typed into the text box:
 
@@ -35,7 +35,7 @@ The following example handles the <xref:System.Windows.Forms.Control.KeyPress> e
 
 ## Modify a standard character key
 
-In a <xref:System.Windows.Forms.Control.KeyPress> event handler, set the <xref:System.Windows.Forms.KeyPressEventArgs.KeyChar%2A> property of the <xref:System.Windows.Forms.KeyPressEventArgs> class to the value of the new character key.
+In a <xref:System.Windows.Forms.Control.KeyPress> event handler, set the <xref:System.Windows.Forms.KeyPressEventArgs.KeyChar*> property of the <xref:System.Windows.Forms.KeyPressEventArgs> class to the value of the new character key.
 
 The following example handles the <xref:System.Windows.Forms.Control.KeyPress> event to change any `A` and `a` character keys to `!`:
 
@@ -44,9 +44,9 @@ The following example handles the <xref:System.Windows.Forms.Control.KeyPress> e
 
 ## Modify a non-character key
 
-You can only modify non-character key presses by inheriting from the control and overriding the <xref:System.Windows.Forms.Control.PreProcessMessage%2A> method. As the input <xref:System.Windows.Forms.Message> is sent to the control, it's processed before the control raises events. You can intercept these messages to modify or block them.
+You can only modify non-character key presses by inheriting from the control and overriding the <xref:System.Windows.Forms.Control.PreProcessMessage*> method. As the input <xref:System.Windows.Forms.Message> is sent to the control, it's processed before the control raises events. You can intercept these messages to modify or block them.
 
-The following code example demonstrates how to use the <xref:System.Windows.Forms.Message.WParam%2A?displayProperty=nameWithType> property of the `m` parameter to change the key pressed. This code detects a key from <kbd>F1</kbd> through <kbd>F10</kbd> and translates the key into a numeric key ranging from <kbd>0</kbd> through <kbd>9</kbd> (where <kbd>F10</kbd> maps to <kbd>0</kbd>).
+The following code example demonstrates how to use the <xref:System.Windows.Forms.Message.WParam*?displayProperty=nameWithType> property of the `m` parameter to change the key pressed. This code detects a key from <kbd>F1</kbd> through <kbd>F10</kbd> and translates the key into a numeric key ranging from <kbd>0</kbd> through <kbd>9</kbd> (where <kbd>F10</kbd> maps to <kbd>0</kbd>).
 
 :::code language="csharp" source="snippets/how-to-change-key-press/csharp/NewTextBox.cs" id="PreProcessMessage":::
 :::code language="vb" source="snippets/how-to-change-key-press/vb/NewTextBox.vb" id="PreProcessMessage":::

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-check-modifier-key.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-check-modifier-key.md
@@ -1,7 +1,7 @@
 ---
 title: "Check which modifier key is pressed"
 description: Learn how to detect when the SHIFT, ALT, or CTRL keys are pressed in Windows Forms for .NET.
-ms.date: 04/02/2025
+ms.date: 07/02/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 dev_langs:
@@ -32,7 +32,7 @@ As the user types keys into your application, you can monitor for pressed modifi
 
 If you handle the <xref:System.Windows.Forms.Control.KeyDown> event, the <xref:System.Windows.Forms.KeyEventArgs.Modifiers?displayProperty=nameWithType> property received by the event handler specifies which modifier keys are pressed. Also, the <xref:System.Windows.Forms.KeyEventArgs.KeyData?displayProperty=nameWithType> property specifies the character that was pressed along with any modifier keys combined with a bitwise OR.
 
-If you're handling the <xref:System.Windows.Forms.Control.KeyPress> event or a mouse event, the event handler doesn't receive this information. Use the <xref:System.Windows.Forms.Control.ModifierKeys%2A> property of the <xref:System.Windows.Forms.Control> class to detect a key modifier. In either case, you must perform a bitwise AND of the appropriate <xref:System.Windows.Forms.Keys> value and the value you're testing. The <xref:System.Windows.Forms.Keys> enumeration offers variations of each modifier key, so it's important that you do the bitwise AND check with the correct value.
+If you're handling the <xref:System.Windows.Forms.Control.KeyPress> event or a mouse event, the event handler doesn't receive this information. Use the <xref:System.Windows.Forms.Control.ModifierKeys*> property of the <xref:System.Windows.Forms.Control> class to detect a key modifier. In either case, you must perform a bitwise AND of the appropriate <xref:System.Windows.Forms.Keys> value and the value you're testing. The <xref:System.Windows.Forms.Keys> enumeration offers variations of each modifier key, so it's important that you do the bitwise AND check with the correct value.
 
 For example, the following key values represent the <kbd>SHIFT</kbd> key:
 
@@ -45,7 +45,7 @@ The correct value to test <kbd>SHIFT</kbd> as a modifier key is <xref:System.Win
 
 ## Detect modifier key
 
-Detect if a modifier key is pressed by comparing the <xref:System.Windows.Forms.Control.ModifierKeys%2A> property and the <xref:System.Windows.Forms.Keys> enumeration value with a bitwise AND operator.
+Detect if a modifier key is pressed by comparing the <xref:System.Windows.Forms.Control.ModifierKeys*> property and the <xref:System.Windows.Forms.Keys> enumeration value with a bitwise AND operator.
 
 The following code example shows how to determine whether the <kbd>SHIFT</kbd> key is pressed within the <xref:System.Windows.Forms.Control.KeyPress> and <xref:System.Windows.Forms.Control.KeyDown> event handlers.
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
@@ -1,7 +1,7 @@
 ---
 title: "Handle keyboard input at the Form level"
 description: Learn how to handle keyboard input for your Windows Forms at the form level, before messages reach a control.
-ms.date: 04/02/2025
+ms.date: 07/01/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 dev_langs:
@@ -19,10 +19,40 @@ Windows Forms provides the ability to handle keyboard messages at the form level
 
 ## Handle a keyboard message
 
-Handle the <xref:System.Windows.Forms.Control.KeyPress> or <xref:System.Windows.Forms.Control.KeyDown> event of the active form and set the <xref:System.Windows.Forms.Form.KeyPreview%2A> property of the form to `true`. This property causes the keyboard to be received by the form before they reach any controls on the form. The following code example handles the <xref:System.Windows.Forms.Control.KeyPress> event by detecting all of the number keys and consuming <kbd>1</kbd>, <kbd>4</kbd>, and <kbd>7</kbd>.
+Handle the <xref:System.Windows.Forms.Control.KeyPress> or <xref:System.Windows.Forms.Control.KeyDown> event of the active form and set the <xref:System.Windows.Forms.Form.KeyPreview%2A> property of the form to `true`. This property causes keyboard input to reach the form before it reaches any controls on the form. The following code example handles the <xref:System.Windows.Forms.Control.KeyPress> event by detecting all of the number keys and consuming <kbd>1</kbd>, <kbd>4</kbd>, and <kbd>7</kbd>.
 
 :::code language="csharp" source="snippets/how-to-handle-forms/csharp/Form1.cs" id="HandleKey":::
 :::code language="vb" source="snippets/how-to-handle-forms/vb/Form1.vb" id="HandleKey":::
+
+## When `KeyPreview` is not enough
+
+Setting `Form.KeyPreview = true` doesn't guarantee that every key reaches form-level event handlers. Certain keys go through preprocessing before standard form events run. Understanding these exceptions is important for handling command keys, dialog keys, and control-specific input correctly.
+
+### Command and dialog key preprocessing
+
+Before form-level keyboard events fire, Windows preprocesses certain keys through these methods (in order):
+
+1. <xref:System.Windows.Forms.Control.ProcessCmdKey%2A>: Intercepts command keys such as menu shortcuts and accelerators. If this method returns `true`, the key is consumed and no event fires.
+2. <xref:System.Windows.Forms.Control.IsInputKey%2A>: Determines whether a key should raise a <xref:System.Windows.Forms.Control.KeyDown> event or go to <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>.
+3. <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>: Handles navigation keys (Escape, Tab, Return, and arrow keys). If processed, no event fires.
+
+If a focused control consumes a key during preprocessing, the form never receives it, regardless of `KeyPreview`.
+
+### Special cases that bypass form-level handlers
+
+- **<kbd>Enter</kbd> and <kbd>Escape</kbd>**: These keys might be handled by <xref:System.Windows.Forms.Form.AcceptButton%2A> and <xref:System.Windows.Forms.Form.CancelButton%2A> before reaching form events.
+- **<kbd>Tab</kbd>**: Often consumed by control focus management and won't reach form handlers.
+- **Menu shortcuts**: Alt key combinations are handled by menu preprocessing.
+
+### Intercepting command keys at the form level
+
+To handle command keys (including menu shortcuts and dialog keys) at the form level, override <xref:System.Windows.Forms.Control.ProcessCmdKey%2A> on your form. This runs during preprocessing, before standard form events.
+
+:::code language="csharp" source="snippets/how-to-handle-forms/csharp/Form1.cs" id="ProcessCmdKey":::
+
+:::code language="vb" source="snippets/how-to-handle-forms/vb/Form1.vb" id="ProcessCmdKey":::
+
+For keys that should raise standard events in a specific control, use <xref:System.Windows.Forms.Control.PreviewKeyDown> with <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> set to `true` on that control.
 
 ## See also
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
@@ -33,8 +33,8 @@ Setting `Form.KeyPreview = true` doesn't guarantee that every key reaches form-l
 Before form-level keyboard events fire, Windows preprocesses certain keys through these methods (in order):
 
 1. <xref:System.Windows.Forms.Control.ProcessCmdKey%2A>: Intercepts command keys such as menu shortcuts and accelerators. If this method returns `true`, the key is consumed and no event fires.
-2. <xref:System.Windows.Forms.Control.IsInputKey%2A>: Determines whether a key should raise a <xref:System.Windows.Forms.Control.KeyDown> event or go to <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>.
-3. <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>: Handles navigation keys (Escape, Tab, Return, and arrow keys). If processed, no event fires.
+1. <xref:System.Windows.Forms.Control.IsInputKey%2A>: Determines whether a key should raise a <xref:System.Windows.Forms.Control.KeyDown> event or go to <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>.
+1. <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>: Handles navigation keys (Escape, Tab, Return, and arrow keys). If processed, no event fires.
 
 If a focused control consumes a key during preprocessing, the form never receives it, regardless of `KeyPreview`.
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
@@ -19,7 +19,7 @@ Windows Forms provides the ability to handle keyboard messages at the form level
 
 ## Handle a keyboard message
 
-Handle the <xref:System.Windows.Forms.Control.KeyPress> or <xref:System.Windows.Forms.Control.KeyDown> event of the active form and set the <xref:System.Windows.Forms.Form.KeyPreview%2A> property of the form to `true`. This property causes keyboard input to reach the form before it reaches any controls on the form. The following code example handles the <xref:System.Windows.Forms.Control.KeyPress> event by detecting all of the number keys and consuming <kbd>1</kbd>, <kbd>4</kbd>, and <kbd>7</kbd>.
+Handle the <xref:System.Windows.Forms.Control.KeyPress> or <xref:System.Windows.Forms.Control.KeyDown> event of the active form and set the <xref:System.Windows.Forms.Form.KeyPreview*> property of the form to `true`. This property causes keyboard input to reach the form before it reaches any controls on the form. The following code example handles the <xref:System.Windows.Forms.Control.KeyPress> event by detecting all of the number keys and consuming <kbd>1</kbd>, <kbd>4</kbd>, and <kbd>7</kbd>.
 
 :::code language="csharp" source="snippets/how-to-handle-forms/csharp/Form1.cs" id="HandleKey":::
 :::code language="vb" source="snippets/how-to-handle-forms/vb/Form1.vb" id="HandleKey":::
@@ -32,27 +32,27 @@ Setting `Form.KeyPreview = true` doesn't guarantee that every key reaches form-l
 
 Before form-level keyboard events fire, Windows preprocesses certain keys through these methods (in order):
 
-1. <xref:System.Windows.Forms.Control.ProcessCmdKey%2A>: Intercepts command keys such as menu shortcuts and accelerators. If this method returns `true`, the key is consumed and no event fires.
-1. <xref:System.Windows.Forms.Control.IsInputKey%2A>: Determines whether a key should raise a <xref:System.Windows.Forms.Control.KeyDown> event or go to <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>.
-1. <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>: Handles navigation keys (Escape, Tab, Return, and arrow keys). If processed, no event fires.
+1. <xref:System.Windows.Forms.Control.ProcessCmdKey*>: Intercepts command keys such as menu shortcuts and accelerators. If this method returns `true`, the key is consumed and no event fires.
+1. <xref:System.Windows.Forms.Control.IsInputKey*>: Determines whether a key should raise a <xref:System.Windows.Forms.Control.KeyDown> event or go to <xref:System.Windows.Forms.Control.ProcessDialogKey*>.
+1. <xref:System.Windows.Forms.Control.ProcessDialogKey*>: Handles navigation keys (Escape, Tab, Return, and arrow keys). If processed, no event fires.
 
 If a focused control consumes a key during preprocessing, the form never receives it, regardless of `KeyPreview`.
 
 ### Special cases that bypass form-level handlers
 
-- **<kbd>Enter</kbd> and <kbd>Escape</kbd>**: These keys might be handled by <xref:System.Windows.Forms.Form.AcceptButton%2A> and <xref:System.Windows.Forms.Form.CancelButton%2A> before reaching form events.
+- **<kbd>Enter</kbd> and <kbd>Escape</kbd>**: These keys might be handled by <xref:System.Windows.Forms.Form.AcceptButton*> and <xref:System.Windows.Forms.Form.CancelButton*> before reaching form events.
 - **<kbd>Tab</kbd>**: Often consumed by control focus management and won't reach form handlers.
 - **Menu shortcuts**: Alt key combinations are handled by menu preprocessing.
 
 ### Intercepting command keys at the form level
 
-To handle command keys (including menu shortcuts and dialog keys) at the form level, override <xref:System.Windows.Forms.Control.ProcessCmdKey%2A> on your form. This runs during preprocessing, before standard form events.
+To handle command keys (including menu shortcuts and dialog keys) at the form level, override <xref:System.Windows.Forms.Control.ProcessCmdKey*> on your form. This runs during preprocessing, before standard form events.
 
 :::code language="csharp" source="snippets/how-to-handle-forms/csharp/Form1.cs" id="ProcessCmdKey":::
 
 :::code language="vb" source="snippets/how-to-handle-forms/vb/Form1.vb" id="ProcessCmdKey":::
 
-For keys that should raise standard events in a specific control, use <xref:System.Windows.Forms.Control.PreviewKeyDown> with <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> set to `true` on that control.
+For keys that should raise standard events in a specific control, use <xref:System.Windows.Forms.Control.PreviewKeyDown> with <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey*> set to `true` on that control.
 
 ## See also
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md
@@ -44,7 +44,7 @@ If a focused control consumes a key during preprocessing, the form never receive
 - **<kbd>Tab</kbd>**: Often consumed by control focus management and won't reach form handlers.
 - **Menu shortcuts**: Alt key combinations are handled by menu preprocessing.
 
-### Intercepting command keys at the form level
+### Intercept command keys at the form level
 
 To handle command keys (including menu shortcuts and dialog keys) at the form level, override <xref:System.Windows.Forms.Control.ProcessCmdKey%2A> on your form. This runs during preprocessing, before standard form events.
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md
@@ -54,6 +54,9 @@ The following code example uses `Send` to simulate pressing keys into the Window
 :::code language="csharp" source="snippets/how-to-simulate-events/csharp/Form2.cs" id="Calculator":::
 :::code language="vb" source="snippets/how-to-simulate-events/vb/Form2.vb" id="Calculator":::
 
+> [!CAUTION]
+> Window title lookup by name is locale-sensitive and can be brittle. Application windows may have localized or renamed titles depending on the system language and user configuration. This sample demonstrates a basic approach only and isn't recommended for production scenarios that need reliability across varied environments. For robust cross-application automation, consider using more reliable methods like window class identification or handle-based lookups, or prefer using UI automation frameworks designed for this purpose.
+
 ## Use OnEventName methods
 
 The easiest way to simulate keyboard events is to call a method on the object that raises the event. Most events have a corresponding method that invokes them, named in the pattern of `On` followed by `EventName`, such as `OnKeyPress`. This option is only possible within custom controls or forms, because these methods are protected and can't be accessed from outside the context of the control or form.

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md
@@ -55,7 +55,7 @@ The following code example uses `Send` to simulate pressing keys into the Window
 :::code language="vb" source="snippets/how-to-simulate-events/vb/Form2.vb" id="Calculator":::
 
 > [!CAUTION]
-> Window title lookup by name is locale-sensitive and can be brittle. Application windows may have localized or renamed titles depending on the system language and user configuration. This sample demonstrates a basic approach only and isn't recommended for production scenarios that need reliability across varied environments. For robust cross-application automation, consider using more reliable methods like window class identification or handle-based lookups, or prefer using UI automation frameworks designed for this purpose.
+> Window title lookup by name is locale-sensitive and can be brittle. Application windows might have localized or renamed titles depending on the system language and user configuration. This sample demonstrates a basic approach only and isn't recommended for production scenarios that need reliability across varied environments. For robust cross-application automation, consider using more reliable methods like window class identification or handle-based lookups, or prefer using UI automation frameworks designed for this purpose.
 
 ## Use OnEventName methods
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md
@@ -1,7 +1,7 @@
 ---
 title: "Simulate keyboard events"
 description: Learn how to simulate keyboard events in Windows Forms for .NET.
-ms.date: 04/02/2025
+ms.date: 07/02/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 dev_langs:
@@ -18,12 +18,12 @@ Windows Forms provides a few options for programmatically simulating keyboard in
 
 ## Use SendKeys
 
-Windows Forms provides the <xref:System.Windows.Forms.SendKeys?displayProperty=fullName> class for sending keystrokes to the active application. There are two methods to send keystrokes to an application: <xref:System.Windows.Forms.SendKeys.Send%2A?displayProperty=nameWithType> and <xref:System.Windows.Forms.SendKeys.SendWait%2A?displayProperty=nameWithType>. The difference between the two methods is that `SendWait` blocks the current thread when the keystroke is sent, waiting for a response, while `Send` doesn't. For more information about `SendWait`, see [To send a keystroke to a different application](#to-send-a-keystroke-to-a-different-application).
+Windows Forms provides the <xref:System.Windows.Forms.SendKeys?displayProperty=fullName> class for sending keystrokes to the active application. There are two methods to send keystrokes to an application: <xref:System.Windows.Forms.SendKeys.Send*?displayProperty=nameWithType> and <xref:System.Windows.Forms.SendKeys.SendWait*?displayProperty=nameWithType>. The difference between the two methods is that `SendWait` blocks the current thread when the keystroke is sent, waiting for a response, while `Send` doesn't. For more information about `SendWait`, see [To send a keystroke to a different application](#to-send-a-keystroke-to-a-different-application).
 
 > [!CAUTION]
-> If your application is intended for international use with various keyboards, the use of <xref:System.Windows.Forms.SendKeys.Send%2A?displayProperty=nameWithType> could yield unpredictable results and should be avoided.
+> If your application is intended for international use with various keyboards, the use of <xref:System.Windows.Forms.SendKeys.Send*?displayProperty=nameWithType> could yield unpredictable results and should be avoided.
 
-Behind the scenes, `SendKeys` uses an older Windows implementation for sending input, which might fail on Windows where it's expected that the application isn't running with administrative rights. If the older implementation fails, the code automatically tries the newer Windows implementation for sending input. Additionally, when the <xref:System.Windows.Forms.SendKeys> class uses the new implementation, the <xref:System.Windows.Forms.SendKeys.SendWait%2A> method no longer blocks the current thread when sending keystrokes to another application.
+Behind the scenes, `SendKeys` uses an older Windows implementation for sending input, which might fail on Windows where it's expected that the application isn't running with administrative rights. If the older implementation fails, the code automatically tries the newer Windows implementation for sending input. Additionally, when the <xref:System.Windows.Forms.SendKeys> class uses the new implementation, the <xref:System.Windows.Forms.SendKeys.SendWait*> method no longer blocks the current thread when sending keystrokes to another application.
 
 > [!IMPORTANT]
 > If your application relies on consistent behavior regardless of the operating system, you can force the <xref:System.Windows.Forms.SendKeys> class to use the new implementation by adding the following application setting to your app.config file.
@@ -38,7 +38,7 @@ Behind the scenes, `SendKeys` uses an older Windows implementation for sending i
 
 ### To send a keystroke to the same application
 
-Call the <xref:System.Windows.Forms.SendKeys.Send%2A?displayProperty=nameWithType> or <xref:System.Windows.Forms.SendKeys.SendWait%2A?displayProperty=nameWithType> method of the <xref:System.Windows.Forms.SendKeys> class. The specified keystrokes are received by the active control of the application.
+Call the <xref:System.Windows.Forms.SendKeys.Send*?displayProperty=nameWithType> or <xref:System.Windows.Forms.SendKeys.SendWait*?displayProperty=nameWithType> method of the <xref:System.Windows.Forms.SendKeys> class. The specified keystrokes are received by the active control of the application.
 
 The following code example uses `Send` to simulate pressing the <kbd>Alt</kbd> and <kbd>Down arrow</kbd> keys together. These keystrokes cause the <xref:System.Windows.Forms.ComboBox> control to display its dropdown. This example assumes a <xref:System.Windows.Forms.Form> with a <xref:System.Windows.Forms.Button> and <xref:System.Windows.Forms.ComboBox>.
 
@@ -47,7 +47,7 @@ The following code example uses `Send` to simulate pressing the <kbd>Alt</kbd> a
 
 ### To send a keystroke to a different application
 
-The <xref:System.Windows.Forms.SendKeys.Send%2A?displayProperty=nameWithType> and <xref:System.Windows.Forms.SendKeys.SendWait%2A?displayProperty=nameWithType> methods send keystrokes to the active application, which is usually the application you're sending keystrokes from. To send keystrokes to another application, you first need to activate it. Because there's no managed method to activate another application, you must use native Windows methods to focus the other application. The following code example uses platform invoke to call the `FindWindow` and `SetForegroundWindow` methods to activate the Calculator application window, and then calls `Send` to issue a series of calculations to the Calculator application.
+The <xref:System.Windows.Forms.SendKeys.Send*?displayProperty=nameWithType> and <xref:System.Windows.Forms.SendKeys.SendWait*?displayProperty=nameWithType> methods send keystrokes to the active application, which is usually the application you're sending keystrokes from. To send keystrokes to another application, you first need to activate it. Because there's no managed method to activate another application, you must use native Windows methods to focus the other application. The following code example uses platform invoke to call the `FindWindow` and `SetForegroundWindow` methods to activate the Calculator application window, and then calls `Send` to issue a series of calculations to the Calculator application.
 
 The following code example uses `Send` to simulate pressing keys into the Windows Calculator application. It first searches for an application window with title of `Calculator` and then activates it. Once activated, the keystrokes are sent to calculate 10 plus 10.
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/overview.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Overview of keyboard input"
 description: Learn about how keyboard input works in Windows Forms for .NET. Keyboard events are raised by forms and controls and represent keys that are down, pressed, or up.
-ms.date: 04/02/2025
+ms.date: 07/01/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 ms.topic: overview
@@ -51,11 +51,23 @@ As listed previously, there are three keyboard related events that can occur on 
 
 Like other messages, keyboard messages are processed in the <xref:System.Windows.Forms.Control.WndProc%2A> method of a form or control. However, before keyboard messages are processed, the <xref:System.Windows.Forms.Control.PreProcessMessage%2A> method calls one or more methods that can be overridden to handle special character keys and physical keys. You can override these methods to detect and filter certain keys before the control processes the messages. The following table shows the action that is being performed and the related method that occurs, in the order that the method occurs.
 
+## Quick decision guide for keyboard interception
+
+Choose the right interception method based on what you're trying to handle:
+
+| What you need | Use this approach |
+|---|---|
+| Filter character input (for example, numbers only, no spaces) | Handle <xref:System.Windows.Forms.Control.KeyPress> event or override <xref:System.Windows.Forms.Control.IsInputChar%2A> |
+| Detect physical keys (for example, Shift, Alt, specific key presses) | Handle <xref:System.Windows.Forms.Control.KeyDown> or <xref:System.Windows.Forms.Control.KeyUp> events |
+| Handle Enter or Tab within a control when normally used for navigation | Handle <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> to `true`, or override <xref:System.Windows.Forms.Control.IsInputKey%2A> |
+| Intercept menu shortcuts or command keys (for example, Ctrl+S) at the form level | Override <xref:System.Windows.Forms.Control.ProcessCmdKey%2A> on the form |
+| Handle application-wide shortcuts before controls get them | Implement <xref:System.Windows.Forms.IMessageFilter> and use <xref:System.Windows.Forms.Application.AddMessageFilter%2A> |
+
 ### Preprocessing for a KeyDown event
 
 |Action|Related method|Notes|
 |------------|--------------------|-----------|
-|Check for a command key such as an accelerator or menu shortcut.|<xref:System.Windows.Forms.Control.ProcessCmdKey%2A>|This method processes a command key, which takes precedence over regular keys. If this method returns `true`, the key message isn't dispatched and a key event doesn't occur. If it returns `false`, <xref:System.Windows.Forms.Control.IsInputKey%2A> is called`.`|
+|Check for a command key such as an accelerator or menu shortcut.|<xref:System.Windows.Forms.Control.ProcessCmdKey%2A>|This method processes a command key, which takes precedence over regular keys. If this method returns `true`, the key message isn't dispatched and a key event doesn't occur. If it returns `false`, <xref:System.Windows.Forms.Control.IsInputKey%2A> is called.|
 |Check for a special key that requires preprocessing or a normal character key that should raise a <xref:System.Windows.Forms.Control.KeyDown> event and be dispatched to a control.|<xref:System.Windows.Forms.Control.IsInputKey%2A>|If the method returns `true`, it means the control is a regular character and a <xref:System.Windows.Forms.Control.KeyDown> event is raised. If `false`, <xref:System.Windows.Forms.Control.ProcessDialogKey%2A> is called. **Note:**  To ensure a control gets a key or combination of keys, you can handle the <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> of the <xref:System.Windows.Forms.PreviewKeyDownEventArgs> to `true` for the key or keys you want.|
 |Check for a navigation key (ESC, TAB, Return, or arrow keys).|<xref:System.Windows.Forms.Control.ProcessDialogKey%2A>|This method processes a physical key that employs special functionality within the control, such as switching focus between the control and its parent. If the immediate control doesn't handle the key, the <xref:System.Windows.Forms.Control.ProcessDialogKey%2A> is called on the parent control, and so on, to the topmost control in the hierarchy. If this method returns `true`, preprocessing is complete and a key event isn't generated. If it returns `false`, a <xref:System.Windows.Forms.Control.KeyDown> event occurs.|
 
@@ -88,6 +100,10 @@ There are many methods available for overriding when a keyboard message is prepr
 |Perform special input or navigation handling during a <xref:System.Windows.Forms.Control.KeyPress> event. For example, in a list control holding down the <kbd>R</kbd> key skips between items that begin with the letter **r**.|Override <xref:System.Windows.Forms.Control.ProcessDialogChar%2A>|
 |Perform custom mnemonic handling; for example, you want to handle mnemonics on owner-drawn buttons contained in a toolbar.|Override <xref:System.Windows.Forms.Control.ProcessMnemonic%2A>.|
 
+## Form-level keyboard input limitations
+
+When handling keyboard input at the form level, be aware of preprocessing exceptions. Not all keys reach form-level handlers when `KeyPreview` is set to `true`. Command keys, dialog keys, and keys consumed by focused controls might bypass form event handlers entirely. For details on these exceptions and how to intercept keys at the preprocessing stage, see [When `KeyPreview` is not enough](how-to-handle-forms.md#when-keypreview-is-not-enough).
+
 ## See also
 
 - <xref:System.Windows.Forms.Keys>
@@ -99,3 +115,4 @@ There are many methods available for overriding when a keyboard message is prepr
 - [How to simulate keyboard events](how-to-simulate-events.md)
 - [How to handle keyboard input messages in the form](how-to-handle-forms.md)
 - [Add a control](../controls/how-to-add-to-a-form.md)
+

--- a/dotnet-desktop-guide/winforms/input-keyboard/overview.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/overview.md
@@ -115,4 +115,3 @@ When handling keyboard input at the form level, be aware of preprocessing except
 - [How to simulate keyboard events](how-to-simulate-events.md)
 - [How to handle keyboard input messages in the form](how-to-handle-forms.md)
 - [Add a control](../controls/how-to-add-to-a-form.md)
-

--- a/dotnet-desktop-guide/winforms/input-keyboard/overview.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/overview.md
@@ -27,11 +27,11 @@ Forms and controls have access to the <xref:System.Windows.Forms.IMessageFilter>
 
 | Method     | Notes |
 |------------|-----------|
-| <xref:System.Windows.Forms.IMessageFilter.PreFilterMessage%2A> | This method intercepts queued (also known as posted) Windows messages at the application level.|
-| <xref:System.Windows.Forms.Control.PreProcessMessage%2A>       | This method intercepts Windows messages at the form and control level before they have been processed.|
-| <xref:System.Windows.Forms.Control.WndProc%2A>                 | This method processes Windows messages at the form and control level.|
-| <xref:System.Windows.Forms.Control.DefWndProc%2A>              | This method performs the default processing of Windows messages at the form and control level. This provides the minimal functionality of a window.|
-| <xref:System.Windows.Forms.Control.OnNotifyMessage%2A>         | This method intercepts messages at the form and control level, after they have been processed. The <xref:System.Windows.Forms.ControlStyles.EnableNotifyMessage> style bit must be set for this method to be called.|
+| <xref:System.Windows.Forms.IMessageFilter.PreFilterMessage*> | This method intercepts queued (also known as posted) Windows messages at the application level.|
+| <xref:System.Windows.Forms.Control.PreProcessMessage*>       | This method intercepts Windows messages at the form and control level before they have been processed.|
+| <xref:System.Windows.Forms.Control.WndProc*>                 | This method processes Windows messages at the form and control level.|
+| <xref:System.Windows.Forms.Control.DefWndProc*>              | This method performs the default processing of Windows messages at the form and control level. This provides the minimal functionality of a window.|
+| <xref:System.Windows.Forms.Control.OnNotifyMessage*>         | This method intercepts messages at the form and control level, after they have been processed. The <xref:System.Windows.Forms.ControlStyles.EnableNotifyMessage> style bit must be set for this method to be called.|
 
 Keyboard and mouse messages are processed by an extra set of overridable methods that are specific to those types of messages. For more information, see the [Preprocessing keys](#preprocessing-keys) section.
 
@@ -49,7 +49,7 @@ As listed previously, there are three keyboard related events that can occur on 
 
 ## Preprocessing keys
 
-Like other messages, keyboard messages are processed in the <xref:System.Windows.Forms.Control.WndProc%2A> method of a form or control. However, before keyboard messages are processed, the <xref:System.Windows.Forms.Control.PreProcessMessage%2A> method calls one or more methods that can be overridden to handle special character keys and physical keys. You can override these methods to detect and filter certain keys before the control processes the messages. The following table shows the action that is being performed and the related method that occurs, in the order that the method occurs.
+Like other messages, keyboard messages are processed in the <xref:System.Windows.Forms.Control.WndProc*> method of a form or control. However, before keyboard messages are processed, the <xref:System.Windows.Forms.Control.PreProcessMessage*> method calls one or more methods that can be overridden to handle special character keys and physical keys. You can override these methods to detect and filter certain keys before the control processes the messages. The following table shows the action that is being performed and the related method that occurs, in the order that the method occurs.
 
 ## Quick decision guide for keyboard interception
 
@@ -57,36 +57,36 @@ Choose the right interception method based on what you're trying to handle:
 
 | What you need | Use this approach |
 |---|---|
-| Filter character input (for example, numbers only, no spaces) | Handle <xref:System.Windows.Forms.Control.KeyPress> event or override <xref:System.Windows.Forms.Control.IsInputChar%2A> |
+| Filter character input (for example, numbers only, no spaces) | Handle <xref:System.Windows.Forms.Control.KeyPress> event or override <xref:System.Windows.Forms.Control.IsInputChar*> |
 | Detect physical keys (for example, Shift, Alt, specific key presses) | Handle <xref:System.Windows.Forms.Control.KeyDown> or <xref:System.Windows.Forms.Control.KeyUp> events |
-| Handle Enter or Tab within a control when normally used for navigation | Handle <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> to `true`, or override <xref:System.Windows.Forms.Control.IsInputKey%2A> |
-| Intercept menu shortcuts or command keys (for example, Ctrl+S) at the form level | Override <xref:System.Windows.Forms.Control.ProcessCmdKey%2A> on the form |
-| Handle application-wide shortcuts before controls get them | Implement <xref:System.Windows.Forms.IMessageFilter> and use <xref:System.Windows.Forms.Application.AddMessageFilter%2A> |
+| Handle Enter or Tab within a control when normally used for navigation | Handle <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey*> to `true`, or override <xref:System.Windows.Forms.Control.IsInputKey*> |
+| Intercept menu shortcuts or command keys (for example, Ctrl+S) at the form level | Override <xref:System.Windows.Forms.Control.ProcessCmdKey*> on the form |
+| Handle application-wide shortcuts before controls get them | Implement <xref:System.Windows.Forms.IMessageFilter> and use <xref:System.Windows.Forms.Application.AddMessageFilter*> |
 
 ### Preprocessing for a KeyDown event
 
 |Action|Related method|Notes|
 |------------|--------------------|-----------|
-|Check for a command key such as an accelerator or menu shortcut.|<xref:System.Windows.Forms.Control.ProcessCmdKey%2A>|This method processes a command key, which takes precedence over regular keys. If this method returns `true`, the key message isn't dispatched and a key event doesn't occur. If it returns `false`, <xref:System.Windows.Forms.Control.IsInputKey%2A> is called.|
-|Check for a special key that requires preprocessing or a normal character key that should raise a <xref:System.Windows.Forms.Control.KeyDown> event and be dispatched to a control.|<xref:System.Windows.Forms.Control.IsInputKey%2A>|If the method returns `true`, it means the control is a regular character and a <xref:System.Windows.Forms.Control.KeyDown> event is raised. If `false`, <xref:System.Windows.Forms.Control.ProcessDialogKey%2A> is called. **Note:**  To ensure a control gets a key or combination of keys, you can handle the <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> of the <xref:System.Windows.Forms.PreviewKeyDownEventArgs> to `true` for the key or keys you want.|
-|Check for a navigation key (ESC, TAB, Return, or arrow keys).|<xref:System.Windows.Forms.Control.ProcessDialogKey%2A>|This method processes a physical key that employs special functionality within the control, such as switching focus between the control and its parent. If the immediate control doesn't handle the key, the <xref:System.Windows.Forms.Control.ProcessDialogKey%2A> is called on the parent control, and so on, to the topmost control in the hierarchy. If this method returns `true`, preprocessing is complete and a key event isn't generated. If it returns `false`, a <xref:System.Windows.Forms.Control.KeyDown> event occurs.|
+|Check for a command key such as an accelerator or menu shortcut.|<xref:System.Windows.Forms.Control.ProcessCmdKey*>|This method processes a command key, which takes precedence over regular keys. If this method returns `true`, the key message isn't dispatched and a key event doesn't occur. If it returns `false`, <xref:System.Windows.Forms.Control.IsInputKey*> is called.|
+|Check for a special key that requires preprocessing or a normal character key that should raise a <xref:System.Windows.Forms.Control.KeyDown> event and be dispatched to a control.|<xref:System.Windows.Forms.Control.IsInputKey*>|If the method returns `true`, it means the control is a regular character and a <xref:System.Windows.Forms.Control.KeyDown> event is raised. If `false`, <xref:System.Windows.Forms.Control.ProcessDialogKey*> is called. **Note:**  To ensure a control gets a key or combination of keys, you can handle the <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey*> of the <xref:System.Windows.Forms.PreviewKeyDownEventArgs> to `true` for the key or keys you want.|
+|Check for a navigation key (ESC, TAB, Return, or arrow keys).|<xref:System.Windows.Forms.Control.ProcessDialogKey*>|This method processes a physical key that employs special functionality within the control, such as switching focus between the control and its parent. If the immediate control doesn't handle the key, the <xref:System.Windows.Forms.Control.ProcessDialogKey*> is called on the parent control, and so on, to the topmost control in the hierarchy. If this method returns `true`, preprocessing is complete and a key event isn't generated. If it returns `false`, a <xref:System.Windows.Forms.Control.KeyDown> event occurs.|
 
 ### Preprocessing for a KeyPress event
 
 |Action|Related method|Notes|
 |------------|--------------------|-----------|
-|Check to see the key is a normal character that should be processed by the control|<xref:System.Windows.Forms.Control.IsInputChar%2A>|If the character is a normal character, this method returns `true`, the <xref:System.Windows.Forms.Control.KeyPress> event is raised and no further preprocessing occurs. Otherwise <xref:System.Windows.Forms.Control.ProcessDialogChar%2A> is called.|
-|Check to see if the character is a mnemonic (such as &OK on a button)|<xref:System.Windows.Forms.Control.ProcessDialogChar%2A>|This method, similar to <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>, is called up the control hierarchy. If the control is a container control, it checks for mnemonics by calling <xref:System.Windows.Forms.Control.ProcessMnemonic%2A> on itself and its child controls. If <xref:System.Windows.Forms.Control.ProcessDialogChar%2A> returns `true`, a <xref:System.Windows.Forms.Control.KeyPress> event doesn't occur.|
+|Check to see the key is a normal character that should be processed by the control|<xref:System.Windows.Forms.Control.IsInputChar*>|If the character is a normal character, this method returns `true`, the <xref:System.Windows.Forms.Control.KeyPress> event is raised and no further preprocessing occurs. Otherwise <xref:System.Windows.Forms.Control.ProcessDialogChar*> is called.|
+|Check to see if the character is a mnemonic (such as &OK on a button)|<xref:System.Windows.Forms.Control.ProcessDialogChar*>|This method, similar to <xref:System.Windows.Forms.Control.ProcessDialogKey*>, is called up the control hierarchy. If the control is a container control, it checks for mnemonics by calling <xref:System.Windows.Forms.Control.ProcessMnemonic*> on itself and its child controls. If <xref:System.Windows.Forms.Control.ProcessDialogChar*> returns `true`, a <xref:System.Windows.Forms.Control.KeyPress> event doesn't occur.|
 
 ## Processing keyboard messages
 
-After keyboard messages reach the <xref:System.Windows.Forms.Control.WndProc%2A> method of a form or control, they're processed by a set of methods that can be overridden. Each of these methods returns a <xref:System.Boolean> value specifying whether the keyboard message has been processed and consumed by the control. If one of the methods returns `true`, then the message is considered handled, and it isn't passed to the control's base or parent for further processing. Otherwise, the message stays in the message queue and might be processed in another method in the control's base or parent. The following table presents the methods that process keyboard messages.
+After keyboard messages reach the <xref:System.Windows.Forms.Control.WndProc*> method of a form or control, they're processed by a set of methods that can be overridden. Each of these methods returns a <xref:System.Boolean> value specifying whether the keyboard message has been processed and consumed by the control. If one of the methods returns `true`, then the message is considered handled, and it isn't passed to the control's base or parent for further processing. Otherwise, the message stays in the message queue and might be processed in another method in the control's base or parent. The following table presents the methods that process keyboard messages.
 
 |Method|Notes|
 |------------|-----------|
-|<xref:System.Windows.Forms.Control.ProcessKeyMessage%2A>|This method processes all keyboard messages that are received by the <xref:System.Windows.Forms.Control.WndProc%2A> method of the control.|
-|<xref:System.Windows.Forms.Control.ProcessKeyPreview%2A>|This method sends the keyboard message to the control's parent. If <xref:System.Windows.Forms.Control.ProcessKeyPreview%2A> returns `true`, no key event is generated, otherwise <xref:System.Windows.Forms.Control.ProcessKeyEventArgs%2A> is called.|
-|<xref:System.Windows.Forms.Control.ProcessKeyEventArgs%2A>|This method raises the <xref:System.Windows.Forms.Control.KeyDown>, <xref:System.Windows.Forms.Control.KeyPress>, and <xref:System.Windows.Forms.Control.KeyUp> events, as appropriate.|
+|<xref:System.Windows.Forms.Control.ProcessKeyMessage*>|This method processes all keyboard messages that are received by the <xref:System.Windows.Forms.Control.WndProc*> method of the control.|
+|<xref:System.Windows.Forms.Control.ProcessKeyPreview*>|This method sends the keyboard message to the control's parent. If <xref:System.Windows.Forms.Control.ProcessKeyPreview*> returns `true`, no key event is generated, otherwise <xref:System.Windows.Forms.Control.ProcessKeyEventArgs*> is called.|
+|<xref:System.Windows.Forms.Control.ProcessKeyEventArgs*>|This method raises the <xref:System.Windows.Forms.Control.KeyDown>, <xref:System.Windows.Forms.Control.KeyPress>, and <xref:System.Windows.Forms.Control.KeyUp> events, as appropriate.|
 
 ## Overriding keyboard methods
 
@@ -94,11 +94,11 @@ There are many methods available for overriding when a keyboard message is prepr
 
 |Task|Method|
 |----------|------------|
-|Intercept a navigation key and raise a <xref:System.Windows.Forms.Control.KeyDown> event. For example, you want <kbd>Tab</kbd> and <kbd>Enter</kbd> to be handled in a text box.|Override <xref:System.Windows.Forms.Control.IsInputKey%2A>. Alternatively, you can handle the <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey%2A> of the <xref:System.Windows.Forms.PreviewKeyDownEventArgs> to `true` for the key or keys you want.|
-|Perform special input or navigation handling on a control. For example, you want the use of arrow keys in your list control to change the selected item.|Override <xref:System.Windows.Forms.Control.ProcessDialogKey%2A>|
-|Intercept a navigation key and raise a <xref:System.Windows.Forms.Control.KeyPress> event. For example in a spin-box control you want multiple arrow key presses to accelerate progression through the items.|Override <xref:System.Windows.Forms.Control.IsInputChar%2A>.|
-|Perform special input or navigation handling during a <xref:System.Windows.Forms.Control.KeyPress> event. For example, in a list control holding down the <kbd>R</kbd> key skips between items that begin with the letter **r**.|Override <xref:System.Windows.Forms.Control.ProcessDialogChar%2A>|
-|Perform custom mnemonic handling; for example, you want to handle mnemonics on owner-drawn buttons contained in a toolbar.|Override <xref:System.Windows.Forms.Control.ProcessMnemonic%2A>.|
+|Intercept a navigation key and raise a <xref:System.Windows.Forms.Control.KeyDown> event. For example, you want <kbd>Tab</kbd> and <kbd>Enter</kbd> to be handled in a text box.|Override <xref:System.Windows.Forms.Control.IsInputKey*>. Alternatively, you can handle the <xref:System.Windows.Forms.Control.PreviewKeyDown> event and set <xref:System.Windows.Forms.PreviewKeyDownEventArgs.IsInputKey*> of the <xref:System.Windows.Forms.PreviewKeyDownEventArgs> to `true` for the key or keys you want.|
+|Perform special input or navigation handling on a control. For example, you want the use of arrow keys in your list control to change the selected item.|Override <xref:System.Windows.Forms.Control.ProcessDialogKey*>|
+|Intercept a navigation key and raise a <xref:System.Windows.Forms.Control.KeyPress> event. For example in a spin-box control you want multiple arrow key presses to accelerate progression through the items.|Override <xref:System.Windows.Forms.Control.IsInputChar*>.|
+|Perform special input or navigation handling during a <xref:System.Windows.Forms.Control.KeyPress> event. For example, in a list control holding down the <kbd>R</kbd> key skips between items that begin with the letter **r**.|Override <xref:System.Windows.Forms.Control.ProcessDialogChar*>|
+|Perform custom mnemonic handling; for example, you want to handle mnemonics on owner-drawn buttons contained in a toolbar.|Override <xref:System.Windows.Forms.Control.ProcessMnemonic*>.|
 
 ## Form-level keyboard input limitations
 
@@ -107,8 +107,8 @@ When handling keyboard input at the form level, be aware of preprocessing except
 ## See also
 
 - <xref:System.Windows.Forms.Keys>
-- <xref:System.Windows.Forms.Control.WndProc%2A>
-- <xref:System.Windows.Forms.Control.PreProcessMessage%2A>
+- <xref:System.Windows.Forms.Control.WndProc*>
+- <xref:System.Windows.Forms.Control.PreProcessMessage*>
 - [Using keyboard events](events.md)
 - [How to modify keyboard key events](how-to-change-key-press.md)
 - [How to Check for modifier key presses](how-to-check-modifier-key.md)

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/csharp/Form1.cs
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/csharp/Form1.cs
@@ -30,19 +30,19 @@ namespace project
         }
 
         //<HandleKey>
-        // Detect all numeric characters at the form level and consume 1,4, and 7.
+        // Detect all numeric characters at the form level and consume 1, 4, and 7.
         // Form.KeyPreview must be set to true for this event handler to be called.
         void Form1_KeyPress(object sender, KeyPressEventArgs e)
         {
-            if (e.KeyChar >= 48 && e.KeyChar <= 57)
+            if (char.IsDigit(e.KeyChar))
             {
                 MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' pressed.");
 
                 switch (e.KeyChar)
                 {
-                    case (char)49:
-                    case (char)52:
-                    case (char)55:
+                    case '1':
+                    case '4':
+                    case '7':
                         MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' consumed.");
                         e.Handled = true;
                         break;
@@ -50,5 +50,20 @@ namespace project
             }
         }
         //</HandleKey>
+
+        // <ProcessCmdKey>
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            // Intercept Ctrl+A for custom handling
+            if (keyData == (Keys.Control | Keys.A))
+            {
+                MessageBox.Show("Ctrl+A intercepted at form level");
+                return true; // Mark as handled
+            }
+
+            // Pass other keys to the base handler
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+        // </ProcessCmdKey>
     }
 }

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/csharp/project.csproj
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/csharp/project.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/vb/Form1.vb
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/vb/Form1.vb
@@ -19,7 +19,7 @@ Partial Public Class Form1
             MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' pressed.")
 
             Select Case e.KeyChar
-                Case "1", "4", "7"
+                Case "1"c, "4"c, "7"c
                     MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' consumed.")
                     e.Handled = True
             End Select

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/vb/Form1.vb
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/vb/Form1.vb
@@ -12,14 +12,14 @@ Partial Public Class Form1
     End Sub
 
     '<HandleKey>
-    ' Detect all numeric characters at the form level and consume 1,4, and 7.
+    ' Detect all numeric characters at the form level and consume 1, 4, and 7.
     ' Form.KeyPreview must be set to true for this event handler to be called.
     Private Sub Form1_KeyPress(sender As Object, e As KeyPressEventArgs)
-        If e.KeyChar >= Chr(48) And e.KeyChar <= Chr(57) Then
+        If Char.IsDigit(e.KeyChar) Then
             MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' pressed.")
 
             Select Case e.KeyChar
-                Case Chr(49), Chr(52), Chr(55)
+                Case "1", "4", "7"
                     MessageBox.Show($"Form.KeyPress: '{e.KeyChar}' consumed.")
                     e.Handled = True
             End Select
@@ -27,5 +27,18 @@ Partial Public Class Form1
 
     End Sub
     '</HandleKey>
+
+    ' <ProcessCmdKey>
+    Protected Overrides Function ProcessCmdKey(ByRef msg As Message, keyData As Keys) As Boolean
+        ' Intercept Ctrl+A for custom handling
+        If keyData = (Keys.Control Or Keys.A) Then
+            MessageBox.Show("Ctrl+A intercepted at form level")
+            Return True ' Mark as handled
+        End If
+
+        ' Pass other keys to the base handler
+        Return MyBase.ProcessCmdKey(msg, keyData)
+    End Function
+    ' </ProcessCmdKey>
 
 End Class

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/vb/projectvb.vbproj
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-handle-forms/vb/projectvb.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>Sub Main</StartupObject>
     <ApplicationManifest>My Project\app.manifest</ApplicationManifest>

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/csharp/Form1.cs
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/csharp/Form1.cs
@@ -21,7 +21,7 @@ namespace project
         private void button1_Click(object sender, EventArgs e)
         {
             comboBox1.Focus();
-            SendKeys.Send("%+{DOWN}");
+            SendKeys.Send("%{DOWN}");
         }
         //</ShowDropDown>
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/csharp/project.csproj
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/csharp/project.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/vb/Form1.vb
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/vb/Form1.vb
@@ -13,7 +13,7 @@ Partial Public Class Form1
     '<ShowDropDown>
     Private Sub Button1_Click(sender As Object, e As EventArgs)
         ComboBox1.Focus()
-        SendKeys.Send("%+{DOWN}")
+        SendKeys.Send("%{DOWN}")
     End Sub
     '</ShowDropDown>
 End Class

--- a/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/vb/projectvb.vbproj
+++ b/dotnet-desktop-guide/winforms/input-keyboard/snippets/how-to-simulate-events/vb/projectvb.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <StartupObject>Sub Main</StartupObject>
   </PropertyGroup>

--- a/dotnet-desktop-guide/winforms/input-keyboard/validation.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/validation.md
@@ -1,7 +1,7 @@
 ---
 title: "User input validation"
 description: Learn about several ways that you can use Windows Forms to validate user input in your applications.
-ms.date: 04/02/2025
+ms.date: 07/01/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 ms.topic: overview
@@ -36,7 +36,7 @@ If you want full programmatic control over validation, or need complex validatio
 
 The <xref:System.Windows.Forms.Control.Validating> event is supplied an object of type <xref:System.ComponentModel.CancelEventArgs>. If you determine that the control's data isn't valid, cancel the <xref:System.Windows.Forms.Control.Validating> event by setting this object's <xref:System.ComponentModel.CancelEventArgs.Cancel%2A> property to `true`. If you don't set the <xref:System.ComponentModel.CancelEventArgs.Cancel%2A> property, Windows Forms assumes that validation succeeded for that control and raises the <xref:System.Windows.Forms.Control.Validated> event.
 
-For a code example that validates an email address in a <xref:System.Windows.Controls.TextBox>, see the <xref:System.Windows.Forms.Control.Validating> event reference.
+For a code example that validates an email address in a <xref:System.Windows.Forms.TextBox>, see the <xref:System.Windows.Forms.Control.Validating> event reference.
 
 ### Event-driven validation data-bound controls
 

--- a/dotnet-desktop-guide/winforms/input-keyboard/validation.md
+++ b/dotnet-desktop-guide/winforms/input-keyboard/validation.md
@@ -1,7 +1,7 @@
 ---
 title: "User input validation"
 description: Learn about several ways that you can use Windows Forms to validate user input in your applications.
-ms.date: 07/01/2026
+ms.date: 07/02/2026
 ms.service: dotnet-desktop
 ms.update-cycle: 365-days
 ms.topic: overview
@@ -34,7 +34,7 @@ If you want full programmatic control over validation, or need complex validatio
 
 - If the postal code must be a valid United States Zip code, you could call a Zip code Web service to validate the data entered by the user.
 
-The <xref:System.Windows.Forms.Control.Validating> event is supplied an object of type <xref:System.ComponentModel.CancelEventArgs>. If you determine that the control's data isn't valid, cancel the <xref:System.Windows.Forms.Control.Validating> event by setting this object's <xref:System.ComponentModel.CancelEventArgs.Cancel%2A> property to `true`. If you don't set the <xref:System.ComponentModel.CancelEventArgs.Cancel%2A> property, Windows Forms assumes that validation succeeded for that control and raises the <xref:System.Windows.Forms.Control.Validated> event.
+The <xref:System.Windows.Forms.Control.Validating> event is supplied an object of type <xref:System.ComponentModel.CancelEventArgs>. If you determine that the control's data isn't valid, cancel the <xref:System.Windows.Forms.Control.Validating> event by setting this object's <xref:System.ComponentModel.CancelEventArgs.Cancel*> property to `true`. If you don't set the <xref:System.ComponentModel.CancelEventArgs.Cancel*> property, Windows Forms assumes that validation succeeded for that control and raises the <xref:System.Windows.Forms.Control.Validated> event.
 
 For a code example that validates an email address in a <xref:System.Windows.Forms.TextBox>, see the <xref:System.Windows.Forms.Control.Validating> event reference.
 
@@ -55,21 +55,21 @@ So when does a control's data get validated? This is up to you, the developer. Y
 
 The implicit validation approach validates data as the user enters it. Validate the data by reading the keys as they're pressed, or more commonly whenever the user takes the input focus away from the control. This approach is useful when you want to give the user immediate feedback about the data as they're working.
 
-If you want to use implicit validation for a control, you must set that control's <xref:System.Windows.Forms.ContainerControl.AutoValidate%2A> property to <xref:System.Windows.Forms.AutoValidate.EnablePreventFocusChange> or <xref:System.Windows.Forms.AutoValidate.EnableAllowFocusChange>. If you cancel the <xref:System.Windows.Forms.Control.Validating> event, the behavior of the control will be determined by what value you assigned to <xref:System.Windows.Forms.ContainerControl.AutoValidate%2A>. If you assigned <xref:System.Windows.Forms.AutoValidate.EnablePreventFocusChange>, canceling the event prevents the <xref:System.Windows.Forms.Control.Validated> event from occurring. Input focus remains on the current control until the user changes the data to a valid format. If you assigned <xref:System.Windows.Forms.AutoValidate.EnableAllowFocusChange>, the <xref:System.Windows.Forms.Control.Validated> event won't occur when you cancel the event, but focus will still change to the next control.
+If you want to use implicit validation for a control, you must set that control's <xref:System.Windows.Forms.ContainerControl.AutoValidate*> property to <xref:System.Windows.Forms.AutoValidate.EnablePreventFocusChange> or <xref:System.Windows.Forms.AutoValidate.EnableAllowFocusChange>. If you cancel the <xref:System.Windows.Forms.Control.Validating> event, the behavior of the control will be determined by what value you assigned to <xref:System.Windows.Forms.ContainerControl.AutoValidate*>. If you assigned <xref:System.Windows.Forms.AutoValidate.EnablePreventFocusChange>, canceling the event prevents the <xref:System.Windows.Forms.Control.Validated> event from occurring. Input focus remains on the current control until the user changes the data to a valid format. If you assigned <xref:System.Windows.Forms.AutoValidate.EnableAllowFocusChange>, the <xref:System.Windows.Forms.Control.Validated> event won't occur when you cancel the event, but focus will still change to the next control.
 
-Assigning <xref:System.Windows.Forms.AutoValidate.Disable> to the <xref:System.Windows.Forms.ContainerControl.AutoValidate%2A> property prevents implicit validation altogether. To validate your controls, use explicit validation.
+Assigning <xref:System.Windows.Forms.AutoValidate.Disable> to the <xref:System.Windows.Forms.ContainerControl.AutoValidate*> property prevents implicit validation altogether. To validate your controls, use explicit validation.
 
 ### Explicit validation
 
 The explicit validation approach validates data at one time. You can validate the data in response to a user action, such as clicking a **Save** button or a **Next** link. When the user action occurs, you can trigger explicit validation in one of the following ways:
 
-- Call <xref:System.Windows.Forms.ContainerControl.Validate%2A> to validate the last control to have lost focus.
-- Call <xref:System.Windows.Forms.ContainerControl.ValidateChildren%2A> to validate all child controls in a form or container control.
+- Call <xref:System.Windows.Forms.ContainerControl.Validate*> to validate the last control to have lost focus.
+- Call <xref:System.Windows.Forms.ContainerControl.ValidateChildren*> to validate all child controls in a form or container control.
 - Call a custom method to validate the data in the controls manually.
 
 ### Default implicit validation behavior for controls
 
-Different Windows Forms controls have different defaults for their <xref:System.Windows.Forms.ContainerControl.AutoValidate%2A> property. The following table shows the most common controls and their defaults.
+Different Windows Forms controls have different defaults for their <xref:System.Windows.Forms.ContainerControl.AutoValidate*> property. The following table shows the most common controls and their defaults.
 
 | Control                                        | Default Validation Behavior                                     |
 |------------------------------------------------|-----------------------------------------------------------------|
@@ -86,9 +86,9 @@ When a control maintains focus because the data it contains is invalid, it's imp
 
 - By clicking the **Close** button.
 - By selecting the **System** > **Close** menu.
-- By calling the <xref:System.Windows.Forms.Form.Close%2A> method programmatically.
+- By calling the <xref:System.Windows.Forms.Form.Close*> method programmatically.
 
-However, in some cases, you might want to let the user close the form regardless of whether the values in the controls are valid. You can override validation and close a form that still contains invalid data by creating a handler for the form's <xref:System.Windows.Forms.Form.FormClosing> event. In the event, set the <xref:System.ComponentModel.CancelEventArgs.Cancel%2A> property to `false`. This forces the form to close. For more information and an example, see <xref:System.Windows.Forms.Form.FormClosing?displayProperty=nameWithType>.
+However, in some cases, you might want to let the user close the form regardless of whether the values in the controls are valid. You can override validation and close a form that still contains invalid data by creating a handler for the form's <xref:System.Windows.Forms.Form.FormClosing> event. In the event, set the <xref:System.ComponentModel.CancelEventArgs.Cancel*> property to `false`. This forces the form to close. For more information and an example, see <xref:System.Windows.Forms.Form.FormClosing?displayProperty=nameWithType>.
 
 > [!NOTE]
 > If you force the form to close in this manner, unsaved data is lost. In addition, modal forms don't validate the contents of controls when they're closed. You can still use control validation to lock focus to a control, but you don't have to be concerned about the behavior associated with closing the form.


### PR DESCRIPTION
Fixes #2235

- Added "When `KeyPreview` is not enough" section to `how-to-handle-forms.md` covering preprocessing exceptions and a `ProcessCmdKey` override example.
- Added a quick decision guide table to `overview.md` for choosing the right keyboard interception API.
- Added "Form-level keyboard input limitations" section to `overview.md` with a cross-link to the new exceptions section.
- Fixed a punctuation artifact in the `overview.md` preprocessing table.
- Fixed incorrect WPF type reference in `validation.md`.
- Added a locale-sensitivity caution to the `SendKeys` example in `how-to-simulate-events.md`.
- Updated `how-to-handle-forms` snippets to use readable character literals instead of numeric char codes.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/winforms/input-keyboard/how-to-change-key-press.md](https://github.com/dotnet/docs-desktop/blob/f88d7321812225ee42ec6002684f0541e6e73423/dotnet-desktop-guide/winforms/input-keyboard/how-to-change-key-press.md) | [dotnet-desktop-guide/winforms/input-keyboard/how-to-change-key-press](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/input-keyboard/how-to-change-key-press?branch=pr-en-us-2254) |
| [dotnet-desktop-guide/winforms/input-keyboard/how-to-check-modifier-key.md](https://github.com/dotnet/docs-desktop/blob/f88d7321812225ee42ec6002684f0541e6e73423/dotnet-desktop-guide/winforms/input-keyboard/how-to-check-modifier-key.md) | [dotnet-desktop-guide/winforms/input-keyboard/how-to-check-modifier-key](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/input-keyboard/how-to-check-modifier-key?branch=pr-en-us-2254) |
| [dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md](https://github.com/dotnet/docs-desktop/blob/f88d7321812225ee42ec6002684f0541e6e73423/dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms.md) | [dotnet-desktop-guide/winforms/input-keyboard/how-to-handle-forms](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/input-keyboard/how-to-handle-forms?branch=pr-en-us-2254) |
| [dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md](https://github.com/dotnet/docs-desktop/blob/f88d7321812225ee42ec6002684f0541e6e73423/dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events.md) | [dotnet-desktop-guide/winforms/input-keyboard/how-to-simulate-events](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/input-keyboard/how-to-simulate-events?branch=pr-en-us-2254) |
| [dotnet-desktop-guide/winforms/input-keyboard/overview.md](https://github.com/dotnet/docs-desktop/blob/f88d7321812225ee42ec6002684f0541e6e73423/dotnet-desktop-guide/winforms/input-keyboard/overview.md) | [dotnet-desktop-guide/winforms/input-keyboard/overview](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/input-keyboard/overview?branch=pr-en-us-2254) |
| [dotnet-desktop-guide/winforms/input-keyboard/validation.md](https://github.com/dotnet/docs-desktop/blob/f88d7321812225ee42ec6002684f0541e6e73423/dotnet-desktop-guide/winforms/input-keyboard/validation.md) | [dotnet-desktop-guide/winforms/input-keyboard/validation](https://review.learn.microsoft.com/en-us/dotnet/desktop/winforms/input-keyboard/validation?branch=pr-en-us-2254) |


<!-- PREVIEW-TABLE-END -->