### PR TITLE
Clarify guidance on loading untrusted XAML, BAML, and XPS content

### DIFF
--- a/dotnet-desktop-guide/wpf/security-wpf.md
+++ b/dotnet-desktop-guide/wpf/security-wpf.md
@@ -271,7 +271,7 @@ The following guidance applies to WPF:
 
 - **Binary XAML (BAML).** BAML is a compiled, tokenized form of XAML that has the same object-construction capabilities as text XAML. BAML is designed to be loaded only from your application's own compiled resources (for example, through <xref:System.Windows.Baml2006.Baml2006Reader>). Treat BAML as trusted only when it originates from a compiled, signed assembly that you produced. Don't load BAML from untrusted streams, files, or documents.
 
-- **XPS and fixed documents.** Document containers such as <xref:System.Windows.Xps.Packaging.XpsDocument>, <xref:System.Windows.Documents.DocumentReference>, and <xref:System.Windows.Documents.PageContent> can reference parts that are loaded as XAML or BAML. Treat an XPS package or fixed document from an untrusted source as untrusted input, and load it in an isolated boundary.
+- **XPS and fixed documents.** Document types such as <xref:System.Windows.Xps.Packaging.XpsDocument>, <xref:System.Windows.Documents.DocumentReference>, and <xref:System.Windows.Documents.PageContent> can reference parts that are loaded as XAML or BAML. Treat an XPS package or fixed document from an untrusted source as untrusted input, and load it in an isolated boundary.
 
 > [!IMPORTANT]
 > A restrictive or allow-list loading mode is a defense-in-depth hardening measure, not a security sandbox. It blocks a set of known-dangerous types, but it still allows many built-in types, some of which can have side effects such as loading external resources or initiating network requests. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.

--- a/dotnet-desktop-guide/wpf/security-wpf.md
+++ b/dotnet-desktop-guide/wpf/security-wpf.md
@@ -39,6 +39,8 @@ This topic contains the following sections:
 
 - [Disabling APTCA Assemblies for Partially Trusted Client Applications](#APTCA)
 
+- [Loading Untrusted XAML, BAML, and XPS Content](#LoadingUntrustedMarkup)
+
 - [Sandbox Behavior for Loose XAML Files](#LooseContentSandboxing)
 
 - [Resources for Developing WPF Applications that Promote Security](#BestPractices)
@@ -257,6 +259,23 @@ If an assembly has to be disabled for partially trusted client applications, you
 > [!NOTE]
 > Core .NET Framework assemblies are not affected by disabling them in this way because they are required for managed applications to run. Support for disabling APTCA assemblies is primarily targeted to third-party applications.
 
+<a name="LoadingUntrustedMarkup"></a>
+
+## Loading Untrusted XAML, BAML, and XPS Content
+
+WPF exposes several APIs that turn markup into live objects. Because XAML directly represents object instantiation and code execution, loading markup from a source you don't control is equivalent to running untrusted code. The application, not the parser, owns the trust decision about the markup it loads. For the general principles, see [XAML security considerations](../xaml-services/security-considerations.md).
+
+The following guidance applies to WPF:
+
+- **Text XAML.** <xref:System.Windows.Markup.XamlReader.Load%2A> and <xref:System.Windows.Markup.XamlReader.Parse%2A> instantiate arbitrary types and set their properties. Don't load XAML from an untrusted stream, string, file, or network location in your application's process. If you must process untrusted markup, isolate the load in a low-privilege boundary, such as a separate process, and treat the result as untrusted.
+
+- **Binary XAML (BAML).** BAML is a compiled, tokenized form of XAML that has the same object-construction capabilities as text XAML. BAML is designed to be loaded only from your application's own compiled resources (for example, through <xref:System.Windows.Baml2006.Baml2006Reader>). Treat BAML as trusted only when it originates from a compiled, signed assembly that you produced. Don't load BAML from untrusted streams, files, or documents.
+
+- **XPS and fixed documents.** Document containers such as <xref:System.Windows.Xps.Packaging.XpsDocument>, <xref:System.Windows.Documents.DocumentReference>, and <xref:System.Windows.Documents.PageContent> can reference parts that are loaded as XAML or BAML. Treat an XPS package or fixed document from an untrusted source as untrusted input, and load it in an isolated boundary.
+
+> [!IMPORTANT]
+> A restrictive or allow-list loading mode is a defense-in-depth hardening measure, not a security sandbox. It blocks a set of known-dangerous types, but it still allows many built-in types, some of which can have side effects such as loading external resources or initiating network requests. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.
+
 <a name="LooseContentSandboxing"></a>
 
 ## Sandbox Behavior for Loose XAML Files
@@ -298,3 +317,4 @@ The following are some additional resources to help develop WPF applications tha
 - [Code Access Security](/dotnet/framework/misc/code-access-security)
 - [ClickOnce Security and Deployment](/visualstudio/deployment/clickonce-security-and-deployment)
 - [XAML in WPF](xaml/index.md)
+- [XAML security considerations](../xaml-services/security-considerations.md)

--- a/dotnet-desktop-guide/xaml-services/security-considerations.md
+++ b/dotnet-desktop-guide/xaml-services/security-considerations.md
@@ -23,6 +23,20 @@ The nature of XAML capabilities gives the XAML the right to construct objects an
 
 In addition to its language-level capabilities, XAML is used for UI definition in many technologies. Loading untrusted XAML might mean loading a malicious spoofing UI.
 
+> [!IMPORTANT]
+> There's no supported way to safely load fully untrusted XAML in-process. XAML loading APIs, such as <xref:System.Xaml.XamlServices.Load%2A> and <xref:System.Xaml.XamlServices.Parse%2A>, instantiate arbitrary types and set their properties, which is equivalent to running arbitrary code. The application, not the parser, owns the trust decision about the markup it loads. If the markup can be influenced by an attacker, isolate the load in a low-privilege boundary, such as a separate process or sandbox, and don't rely on the parser to make it safe.
+
+### Compiled and binary forms of XAML
+
+Some technologies compile XAML into a binary or tokenized form that's loaded at run time. A binary form of XAML has the same object-construction capabilities as the equivalent text XAML, so it carries the same trust considerations. Treat a binary XAML source as trusted only when it originates from a compiled, signed assembly or resource that you produced. Don't load a binary XAML source that comes from an untrusted stream, file, or document, and be aware that a container format might embed such content as one of its parts.
+
+### Restrictive readers are a hardening measure, not a sandbox
+
+A loading path might offer a restrictive or allow-list reader that blocks a set of known-dangerous types. This kind of reader is a useful defense-in-depth hardening step, but it isn't a security sandbox. A restrictive reader can still allow many built-in types, including types that have side effects such as reaching out to network resources. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.
+
+> [!NOTE]
+> Individual frameworks build on .NET XAML Services and add their own loaders, binary XAML formats, and document containers. For framework-specific guidance about loading untrusted markup in Windows Presentation Foundation (WPF), see [Security (WPF)](../wpf/security-wpf.md).
+
 ## Sharing Context Between Readers and Writers
 
 .NET XAML Services architecture for XAML readers and XAML writers often requires sharing a XAML reader to a XAML writer, or a shared XAML schema context. Sharing objects or contexts might be required if you are writing XAML node loop logic, or providing a custom save path. Don't share XAML reader instances, nondefault XAML schema context, or settings for XAML reader/writer classes between trusted and untrusted code.


### PR DESCRIPTION
## Summary

Clarifies security guidance for loading untrusted markup (XAML, BAML, and XPS/fixed documents) across the desktop docs. The core message: loading markup from a source you don't control is equivalent to running untrusted code, and restrictive/allow-list loading is a defense-in-depth hardening measure — not a security sandbox.

## Changes

- **`xaml-services/security-considerations.md`** (platform-agnostic .NET XAML Services)
  - Added an Important note that there's no supported way to safely load fully untrusted XAML in-process, and that the application — not the parser — owns the trust decision.
  - Added generic guidance on compiled/binary forms of XAML and on restrictive readers as hardening rather than a sandbox.
  - Added a cross-link to the WPF-specific security article.
- **`wpf/security-wpf.md`** (WPF-specific)
  - Added a new section, *Loading Untrusted XAML, BAML, and XPS Content*, covering text XAML, binary XAML (BAML), and XPS/fixed-document containers.
  - Added an Important note that a restrictive/allow-list load isn't a security sandbox.
  - Updated the contents list and See also, with a cross-link back to the XAML Services article.

## Why

The existing articles stated the general "treat untrusted XAML like untrusted code" principle but didn't explicitly cover binary XAML (BAML) or document-container inputs, and didn't clarify that restrictive loading is a hardening step rather than a safe boundary. This adds that guidance so developers make correct trust decisions.

## Notes

- Guidance is intentionally generic; it names the relevant public loading APIs but doesn't describe specific exploit techniques.
- All API references use validated cross-references (`<xref:...>`) to public APIs.
- Documentation-only change — no code or samples added.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [dotnet-desktop-guide/wpf/security-wpf.md](https://github.com/dotnet/docs-desktop/blob/b203a9479a751f59705bd43936479e88bb3122b6/dotnet-desktop-guide/wpf/security-wpf.md) | [dotnet-desktop-guide/wpf/security-wpf](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/security-wpf?branch=pr-en-us-2261) |
| [dotnet-desktop-guide/xaml-services/security-considerations.md](https://github.com/dotnet/docs-desktop/blob/b203a9479a751f59705bd43936479e88bb3122b6/dotnet-desktop-guide/xaml-services/security-considerations.md) | [dotnet-desktop-guide/xaml-services/security-considerations](https://review.learn.microsoft.com/en-us/dotnet/desktop/xaml-services/security-considerations?branch=pr-en-us-2261) |


<!-- PREVIEW-TABLE-END -->