### PR TITLE
Updating doc to set correct expectations when using restrictive XAML mode in WPF

### DIFF
--- a/dotnet-desktop-guide/wpf/security-wpf.md
+++ b/dotnet-desktop-guide/wpf/security-wpf.md
@@ -31,18 +31,19 @@ This topic discusses the security model for Windows Presentation Foundation (WPF
 
 This topic contains the following sections:
 
-- [Security (WPF)](#security-wpf)
-  - [Safe Navigation](#safe-navigation)
-    - [Application Navigation Security](#application-navigation-security)
-    - [Browser Navigation Security](#browser-navigation-security)
-  - [Web Browsing Software Security Settings](#web-browsing-software-security-settings)
-    - [Security-related WPF Registry Settings](#security-related-wpf-registry-settings)
-  - [WebBrowser Control and Feature Controls](#webbrowser-control-and-feature-controls)
-  - [Disabling APTCA Assemblies for Partially Trusted Client Applications](#disabling-aptca-assemblies-for-partially-trusted-client-applications)
-  - [Sandbox Behavior for Loose XAML Files](#sandbox-behavior-for-loose-xaml-files)
-    - [Restrictive XAML reader mode](#restrictive-xaml-reader-mode)
-  - [Resources for Developing WPF Applications that Promote Security](#resources-for-developing-wpf-applications-that-promote-security)
-  - [See also](#see-also)
+- [Safe Navigation](#SafeTopLevelNavigation)
+
+- [Web Browsing Software Security Settings](#InternetExplorerSecuritySettings)
+
+- [WebBrowser Control and Feature Controls](#webbrowser_control_and_feature_controls)
+
+- [Disabling APTCA Assemblies for Partially Trusted Client Applications](#APTCA)
+
+- [Loading Untrusted XAML, BAML, and XPS Content](#LoadingUntrustedMarkup)
+
+- [Sandbox Behavior for Loose XAML Files](#LooseContentSandboxing)
+
+- [Resources for Developing WPF Applications that Promote Security](#BestPractices)
 
 <a name="SafeTopLevelNavigation"></a>
 

--- a/dotnet-desktop-guide/wpf/security-wpf.md
+++ b/dotnet-desktop-guide/wpf/security-wpf.md
@@ -281,7 +281,7 @@ With this setting, external content will be loaded into a process that is separa
 
 ### Restrictive XAML reader mode
 
-WPF uses the `useRestrictiveXamlReader` mode in some infrastructure loading paths to restrict the instantiation of potentially dangerous types. This mode runs in the caller's process. However, unlike `SandboxExternalContent`, it doesn't create a low-privilege security boundary.
+You might encounter the `useRestrictiveXamlReader` mode in some WPF infrastructure loading paths. It restricts the instantiation of potentially dangerous types, but it still runs in your process and doesn't create a low-privilege security boundary like **SandboxExternalContent** does.
 
 > [!IMPORTANT]
 > A restrictive or allow-list loading mode is a defense-in-depth hardening measure, not a security sandbox. It blocks a set of known-dangerous types, but it still allows many built-in types, some of which can have side effects such as loading external resources or initiating network requests. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.

--- a/dotnet-desktop-guide/wpf/security-wpf.md
+++ b/dotnet-desktop-guide/wpf/security-wpf.md
@@ -1,7 +1,7 @@
 ---
 title: "Security"
 description: Learn about the security model followed when developing Windows Presentation Foundation (WPF) standalone and browser-hosted applications.
-ms.date: "03/30/2017"
+ms.date: "08/21/2026"
 ms.service: dotnet-framework
 ms.update-cycle: 1825-days
 helpviewer_keywords:
@@ -31,19 +31,18 @@ This topic discusses the security model for Windows Presentation Foundation (WPF
 
 This topic contains the following sections:
 
-- [Safe Navigation](#SafeTopLevelNavigation)
-
-- [Web Browsing Software Security Settings](#InternetExplorerSecuritySettings)
-
-- [WebBrowser Control and Feature Controls](#webbrowser_control_and_feature_controls)
-
-- [Disabling APTCA Assemblies for Partially Trusted Client Applications](#APTCA)
-
-- [Loading Untrusted XAML, BAML, and XPS Content](#LoadingUntrustedMarkup)
-
-- [Sandbox Behavior for Loose XAML Files](#LooseContentSandboxing)
-
-- [Resources for Developing WPF Applications that Promote Security](#BestPractices)
+- [Security (WPF)](#security-wpf)
+  - [Safe Navigation](#safe-navigation)
+    - [Application Navigation Security](#application-navigation-security)
+    - [Browser Navigation Security](#browser-navigation-security)
+  - [Web Browsing Software Security Settings](#web-browsing-software-security-settings)
+    - [Security-related WPF Registry Settings](#security-related-wpf-registry-settings)
+  - [WebBrowser Control and Feature Controls](#webbrowser-control-and-feature-controls)
+  - [Disabling APTCA Assemblies for Partially Trusted Client Applications](#disabling-aptca-assemblies-for-partially-trusted-client-applications)
+  - [Sandbox Behavior for Loose XAML Files](#sandbox-behavior-for-loose-xaml-files)
+    - [Restrictive XAML reader mode](#restrictive-xaml-reader-mode)
+  - [Resources for Developing WPF Applications that Promote Security](#resources-for-developing-wpf-applications-that-promote-security)
+  - [See also](#see-also)
 
 <a name="SafeTopLevelNavigation"></a>
 
@@ -259,23 +258,6 @@ If an assembly has to be disabled for partially trusted client applications, you
 > [!NOTE]
 > Core .NET Framework assemblies are not affected by disabling them in this way because they are required for managed applications to run. Support for disabling APTCA assemblies is primarily targeted to third-party applications.
 
-<a name="LoadingUntrustedMarkup"></a>
-
-## Loading Untrusted XAML, BAML, and XPS Content
-
-WPF exposes several APIs that turn markup into live objects. Because XAML directly represents object instantiation and code execution, loading markup from a source you don't control is equivalent to running untrusted code. The application, not the parser, owns the trust decision about the markup it loads. For the general principles, see [XAML security considerations](../xaml-services/security-considerations.md).
-
-The following guidance applies to WPF:
-
-- **Text XAML.** <xref:System.Windows.Markup.XamlReader.Load%2A> and <xref:System.Windows.Markup.XamlReader.Parse%2A> instantiate arbitrary types and set their properties. Don't load XAML from an untrusted stream, string, file, or network location in your application's process. If you must process untrusted markup, isolate the load in a low-privilege boundary, such as a separate process, and treat the result as untrusted.
-
-- **Binary XAML (BAML).** BAML is a compiled, tokenized form of XAML that has the same object-construction capabilities as text XAML. BAML is designed to be loaded only from your application's own compiled resources (for example, through <xref:System.Windows.Baml2006.Baml2006Reader>). Treat BAML as trusted only when it originates from a compiled, signed assembly that you produced. Don't load BAML from untrusted streams, files, or documents.
-
-- **XPS and fixed documents.** Document types such as <xref:System.Windows.Xps.Packaging.XpsDocument>, <xref:System.Windows.Documents.DocumentReference>, and <xref:System.Windows.Documents.PageContent> can reference parts that are loaded as XAML or BAML. Treat an XPS package or fixed document from an untrusted source as untrusted input, and load it in an isolated boundary.
-
-> [!IMPORTANT]
-> A restrictive or allow-list loading mode is a defense-in-depth hardening measure, not a security sandbox. It blocks a set of known-dangerous types, but it still allows many built-in types, some of which can have side effects such as loading external resources or initiating network requests. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.
-
 <a name="LooseContentSandboxing"></a>
 
 ## Sandbox Behavior for Loose XAML Files
@@ -296,6 +278,13 @@ With this setting, external content will be loaded into a process that is separa
 
 > [!NOTE]
 > Even though navigation to loose XAML files from either a <xref:System.Windows.Navigation.NavigationWindow> or <xref:System.Windows.Controls.Frame> in a standalone application is implemented based on the WPF browser hosting infrastructure, involving the PresentationHost process, the security level is slightly less than when the content is loaded directly in Internet Explorer on Windows Vista and Windows 7 (which would still be through PresentationHost). This is because a standalone WPF application using a Web browser does not provide the additional Protected Mode security feature of Internet Explorer.
+
+### Restrictive XAML reader mode
+
+WPF uses the `useRestrictiveXamlReader` mode in some infrastructure loading paths to restrict the instantiation of potentially dangerous types. This mode runs in the caller's process. However, unlike `SandboxExternalContent`, it doesn't create a low-privilege security boundary.
+
+> [!IMPORTANT]
+> A restrictive or allow-list loading mode is a defense-in-depth hardening measure, not a security sandbox. It blocks a set of known-dangerous types, but it still allows many built-in types, some of which can have side effects such as loading external resources or initiating network requests. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.
 
 <a name="BestPractices"></a>
 
@@ -319,4 +308,3 @@ The following are some additional resources to help develop WPF applications tha
 - [Code Access Security](/dotnet/framework/misc/code-access-security)
 - [ClickOnce Security and Deployment](/visualstudio/deployment/clickonce-security-and-deployment)
 - [XAML in WPF](xaml/index.md)
-- [XAML security considerations](../xaml-services/security-considerations.md)

--- a/dotnet-desktop-guide/xaml-services/security-considerations.md
+++ b/dotnet-desktop-guide/xaml-services/security-considerations.md
@@ -1,7 +1,7 @@
 ---
 title: "XAML Security Considerations"
 description: Learn about the best practices for security in applications when you use XAML and .NET XAML Services API.
-ms.date: 12/16/2025
+ms.date: 08/21/2026
 helpviewer_keywords:
   - "security [XAML Services], .NET XAML services"
   - "XAML security [XAML Services]"
@@ -22,20 +22,6 @@ For untrusted XAML, you should treat it generally the same as if it were untrust
 The nature of XAML capabilities gives the XAML the right to construct objects and set their properties. These capabilities also include accessing type converters, mapping and accessing assemblies in the application domain, using markup extensions, `x:Code` blocks, and so on.
 
 In addition to its language-level capabilities, XAML is used for UI definition in many technologies. Loading untrusted XAML might mean loading a malicious spoofing UI.
-
-> [!IMPORTANT]
-> There's no supported way to safely load fully untrusted XAML in-process. XAML loading APIs, such as <xref:System.Xaml.XamlServices.Load%2A> and <xref:System.Xaml.XamlServices.Parse%2A>, instantiate arbitrary types and set their properties, which is equivalent to running arbitrary code. The application, not the parser, owns the trust decision about the markup it loads. If the markup can be influenced by an attacker, isolate the load in a low-privilege boundary, such as a separate process or sandbox, and don't rely on the parser to make it safe.
-
-### Compiled and binary forms of XAML
-
-Some technologies compile XAML into a binary or tokenized form that's loaded at run time. A binary form of XAML has the same object-construction capabilities as the equivalent text XAML, so it carries the same trust considerations. Treat a binary XAML source as trusted only when it originates from a compiled, signed assembly or resource that you produced. Don't load a binary XAML source that comes from an untrusted stream, file, or document, and be aware that a container format might embed such content as one of its parts.
-
-### Restrictive readers are a hardening measure, not a sandbox
-
-A loading path might offer a restrictive or allow-list reader that blocks a set of known-dangerous types. This kind of reader is a useful defense-in-depth hardening step, but it isn't a security sandbox. A restrictive reader can still allow many built-in types, including types that have side effects such as reaching out to network resources. Don't treat a restrictive parse of untrusted markup as safe. Continue to isolate untrusted markup in a low-privilege boundary.
-
-> [!NOTE]
-> Individual frameworks build on .NET XAML Services and add their own loaders, binary XAML formats, and document containers. For framework-specific guidance about loading untrusted markup in Windows Presentation Foundation (WPF), see [Security (WPF)](../wpf/security-wpf.md).
 
 ## Sharing Context Between Readers and Writers
 


### PR DESCRIPTION
### Summary

Reverting the security guidance added in #2261 for loading untrusted XAML, BAML and XPS packages. Most of the added changes are redundant as the expectations for the above scenario is already present in the doc. However, retaining the doc changes on restrictive XAML reader mode in WPF as the latest findings suggested that lack of documentation regarding this mode is setting wrong expectations for the developers. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [dotnet-desktop-guide/wpf/security-wpf.md](https://github.com/dotnet/docs-desktop/blob/eb22b04f57fa29402acdfaff9c5d25a04da7e338/dotnet-desktop-guide/wpf/security-wpf.md) | [dotnet-desktop-guide/wpf/security-wpf](https://review.learn.microsoft.com/en-us/dotnet/desktop/wpf/security-wpf?branch=pr-en-us-2278) |
| [dotnet-desktop-guide/xaml-services/security-considerations.md](https://github.com/dotnet/docs-desktop/blob/eb22b04f57fa29402acdfaff9c5d25a04da7e338/dotnet-desktop-guide/xaml-services/security-considerations.md) | [dotnet-desktop-guide/xaml-services/security-considerations](https://review.learn.microsoft.com/en-us/dotnet/desktop/xaml-services/security-considerations?branch=pr-en-us-2278) |


<!-- PREVIEW-TABLE-END -->